### PR TITLE
feat: render copy button as icon only

### DIFF
--- a/app/components/item.tsx
+++ b/app/components/item.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import QRCode from "react-qr-code"
-import { Button, Dialog, Text } from "@fedibtc/ui"
+import { Button, Dialog, Icon, Text } from "@fedibtc/ui"
 import Flex from "./flex"
 import { useViewport } from "./viewport-provider"
 import { useState } from "react"
@@ -58,25 +58,31 @@ export default function CatalogItem({
   }
 
   const renderActionButton = () => {
-    const isDisabled = targetActionType === "install" && isInstalled
+    if (targetActionType === 'install') {
+      const installButtonText = isInstalled ? "Added" : "Add"
 
-    let buttonText = "Copy"
-
-    if (targetActionType === "install") {
-      buttonText = isInstalled ? "Added" : "Add"
+      return (
+        <Button
+          className="w-8 px-10 bg-black text-white"
+          disabled={isInstalled}
+          loading={isPerformingAction}
+          variant="secondary"
+          onClick={handleAction}
+        >
+          {installButtonText}
+        </Button>
+      )
+    } else {
+      return (
+        <Button
+          className="rounded-full p-3"
+          variant="secondary"
+          onClick={handleAction}
+        >
+          <Icon icon="IconCopy" className="h-6 max-h-6 w-6 max-w-6" />
+        </Button>
+      )
     }
-
-    return (
-      <Button
-        className="w-8 px-10 bg-black text-white"
-        disabled={isDisabled}
-        loading={isPerformingAction}
-        variant="secondary"
-        onClick={handleAction}
-      >
-        {buttonText}
-      </Button>
-    )
   }
 
   const modalContent = (

--- a/app/components/item.tsx
+++ b/app/components/item.tsx
@@ -109,17 +109,17 @@ export default function CatalogItem({
               <Icon icon="IconCopy" className="h-4 max-h-4 w-4 max-w-4" />
             </Button>
 
-            {targetActionType === 'install' &&
-                <Button
-                  className="bg-black text-white h-8 p-4"
-                  disabled={isInstalled}
-                  loading={isPerformingAction}
-                  variant="secondary"
-                  onClick={handleAction}
-                >
-                  {isInstalled ? 'Added' : 'Add'}
-                </Button>
-            }
+            {targetActionType === "install" && (
+              <Button
+                className="bg-black text-white h-8 p-4"
+                disabled={isInstalled}
+                loading={isPerformingAction}
+                variant="secondary"
+                onClick={handleAction}
+              >
+                {isInstalled ? "Added" : "Add"}
+              </Button>
+            )}
           </div>
         </Flex>
       </Container>

--- a/app/components/item.tsx
+++ b/app/components/item.tsx
@@ -57,34 +57,6 @@ export default function CatalogItem({
     setIsPerformingAction(false)
   }
 
-  const renderActionButton = () => {
-    if (targetActionType === 'install') {
-      const installButtonText = isInstalled ? "Added" : "Add"
-
-      return (
-        <Button
-          className="w-8 px-10 bg-black text-white"
-          disabled={isInstalled}
-          loading={isPerformingAction}
-          variant="secondary"
-          onClick={handleAction}
-        >
-          {installButtonText}
-        </Button>
-      )
-    } else {
-      return (
-        <Button
-          className="rounded-full p-3"
-          variant="secondary"
-          onClick={handleAction}
-        >
-          <Icon icon="IconCopy" className="h-6 max-h-6 w-6 max-w-6" />
-        </Button>
-      )
-    }
-  }
-
   const modalContent = (
     <Flex col gap={2} className="min-w-[320px] shrink-0">
       <Flex
@@ -96,8 +68,6 @@ export default function CatalogItem({
       >
         <QRCode value={content.url} size={256} />
       </Flex>
-
-      {renderActionButton()}
     </Flex>
   )
 
@@ -110,17 +80,18 @@ export default function CatalogItem({
             setIsOpen(true)
           }
         }}
+        className="p-2"
       >
-        <Flex grow gap={2}>
+        <Flex grow align="center" gap={2}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={content.iconUrl}
             width={64}
             height={64}
             alt={content.name}
-            className="rounded-lg border border-extraLightGrey w-16 h-16 shrink-0"
+            className="rounded-lg self-start border border-extraLightGrey w-16 h-16 shrink-0"
           />
-          <Flex col gap={2} grow>
+          <Flex col gap={1} grow>
             <Text weight="medium">
               <HighlightText content={content.name} query={query} />
             </Text>
@@ -129,7 +100,27 @@ export default function CatalogItem({
             </Text>
           </Flex>
 
-          {renderActionButton()}
+          <div className="flex gap-1 items-center">
+            <Button
+              className="rounded-full h-4 w-4 p-4"
+              variant="secondary"
+              onClick={handleAction}
+            >
+              <Icon icon="IconCopy" className="h-4 max-h-4 w-4 max-w-4" />
+            </Button>
+
+            {targetActionType === 'install' &&
+                <Button
+                  className="bg-black text-white h-8 p-4"
+                  disabled={isInstalled}
+                  loading={isPerformingAction}
+                  variant="secondary"
+                  onClick={handleAction}
+                >
+                  {isInstalled ? 'Added' : 'Add'}
+                </Button>
+            }
+          </div>
         </Flex>
       </Container>
       {!isMobile && (


### PR DESCRIPTION
This PR renders the Copy button as an icon only, to meet product requirements. It previously rendered a black button with "Copy" text. It also renders both the copy and add buttons, if possible.

Before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2025-12-10 at 10 16 55" src="https://github.com/user-attachments/assets/ceb4f8aa-65d4-4959-b58f-05300c790e8f" />

After:
<img width="406" height="862" alt="Screenshot 2025-12-05 at 4 59 32 PM" src="https://github.com/user-attachments/assets/80c35e56-c492-4d8b-aae8-1ffa7ac65b17" />
<img width="413" height="867" alt="Screenshot 2025-12-05 at 5 02 58 PM" src="https://github.com/user-attachments/assets/c36d310b-24fa-40df-88ee-fbdd23f77ebd" />
