### PR TITLE
chore: add error toast to copy action

### DIFF
--- a/app/components/item.tsx
+++ b/app/components/item.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import QRCode from "react-qr-code"
 import { Button, Dialog, Icon, Text } from "@fedibtc/ui"
 import Flex from "./flex"

--- a/app/content.tsx
+++ b/app/content.tsx
@@ -1,9 +1,8 @@
 "use client"
 
-import { Button, Dialog, Icon, Text, useToast } from "@fedibtc/ui"
+import { Dialog, Icon, Text, useToast } from "@fedibtc/ui"
 import { useCallback, useEffect, useState } from "react"
 import { useSearchParams } from "next/navigation"
-
 import CatalogItem from "./components/item"
 import Flex from "./components/flex"
 import { Mod } from "./lib/schemas"
@@ -12,8 +11,6 @@ import FilteredMiniAppsList from "./components/FilteredMiniAppsList"
 import MiniAppsFilter from "./components/MiniAppsFilter/MiniAppsFilter"
 import MiniAppGroup from "./components/miniAppGroup"
 import { useViewport } from "./components/viewport-provider"
-import { styled } from "react-tailwind-variants"
-import { categoriesByCode } from "./lib/categories"
 import MiniAppDetails from "./components/MiniAppDetails"
 
 export default function PageContent({
@@ -50,9 +47,16 @@ export default function PageContent({
   }, [])
 
   const copyMiniAppUrl = (miniApp: Mod) => {
-    return navigator.clipboard.writeText(miniApp.url).then(() => {
-      toast.show("Copied to clipboard")
-    })
+    return navigator.clipboard
+      .writeText(miniApp.url)
+      .then(() => {
+        toast.show("Copied to clipboard")
+      })
+      .catch(() => {
+        toast.show(
+          "Failed to copy to clipboard, please check that your browser has the correct permissions",
+        )
+      })
   }
 
   const installMiniApp = async (miniApp: Mod) => {


### PR DESCRIPTION
It's better to display an error than to do nothing.

I removed the `"use client"` from `item.tsx` because it was causing an eslint error. Its parent `content.tsx` already has `"use client"` in it.

Helps with https://github.com/fedibtc/fedi/issues/9781.