### PR TITLE
fix: check for v2+

### DIFF
--- a/app/content.tsx
+++ b/app/content.tsx
@@ -90,7 +90,7 @@ export default function PageContent({
     )
 
     useEffect(() => {
-        if (window.fediInternal?.version === 2) {
+        if (window.fediInternal?.version >= 2) {
             // eslint-disable-next-line
             setFediApiAvailable(true)
         }


### PR DESCRIPTION
- ref https://github.com/fedibtc/fedi/issues/10205
- v26.2 of the fedi app bumped to v3 so this broke the Add button