### PR TITLE
fix: typo breaking image

### DIFF
--- a/mods/cash-in-cash-out/bitspenda/meta.json
+++ b/mods/cash-in-cash-out/bitspenda/meta.json
@@ -2,6 +2,6 @@
   "name": "Bitspenda",
   "id": "bitspenda",
   "url": "https://send.bitspenda.app",
-  "iconUrl": "htpps://send.bitspenda.app/logo.png",
+  "iconUrl": "https://send.bitspenda.app/logo.png",
   "description": "Spend Bitcoin seamlessly with instant mobile money payouts in Ghana, Kenya and Nigeria."
 }


### PR DESCRIPTION
fixes this:

<img width="300" alt="Screenshot_1770712691" src="https://github.com/user-attachments/assets/2e22417a-3651-4f1f-ada1-44b65842fbbd" />
