### PR TITLE
chore: fix url equality check

### DIFF
--- a/app/content.tsx
+++ b/app/content.tsx
@@ -114,7 +114,10 @@ export default function PageContent({
 
     const isMiniAppInstalled = (miniApp: Mod): boolean => {
         return installedMiniApps.some((installedMiniApp) => {
-            return installedMiniApp.url === miniApp.url
+            return (
+                new URL(installedMiniApp.url).toString() ===
+                new URL(miniApp.url).toString()
+            )
         })
     }
 


### PR DESCRIPTION
Contributes to https://github.com/fedibtc/fedi/issues/9780

In Fedi vs the catalog, bitrefill was missing a "/" before the query string, resulting in the two strings not being equal

This commit uses the `URL` constructor to stringify URLs and properly convert them to strings