### PR TITLE
fix: infinite useEffect loop for filter

### DIFF
--- a/app/components/MiniAppsFilter/MiniAppsFilter.tsx
+++ b/app/components/MiniAppsFilter/MiniAppsFilter.tsx
@@ -200,6 +200,9 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
         } else {
             onFilteredListChange(null)
         }
+        // Do NOT add `onFilterSearchChange` or `allMiniApps` as dependencies
+        // or you will get an infinite useEffect loop
+        // eslint-disable-next-line
     }, [
         hasModalFiltersApplied,
         miniAppSearch,
@@ -207,8 +210,6 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
         matchesSelectedCountries,
         matchesSelectedCategories,
         matchesSearch,
-        allMiniApps,
-        onFilteredListChange,
     ])
 
     useEffect(() => {


### PR DESCRIPTION
Addresses https://github.com/fedibtc/fedi/issues/10100

I blindly added two new dependencies to the filter useEffect because eslint said to (it was wrong)