### PR TITLE
chore: revert useEffect dependency addition (again)

### DIFF
--- a/app/components/MiniAppsFilter/MiniAppsFilter.tsx
+++ b/app/components/MiniAppsFilter/MiniAppsFilter.tsx
@@ -214,7 +214,9 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
 
     useEffect(() => {
         onFilterSearchChange(miniAppSearch)
-    }, [miniAppSearch, onFilterSearchChange])
+        // Do NOT add `onFilterSearchChange` as dependency
+        // eslint-disable-next-line
+    }, [miniAppSearch])
 
     return (
         <Flex col width="full">


### PR DESCRIPTION
I found one more dependency I'd added to hide an eslint warning. This will hopefully prevent unintended behavior from happening.