### PR TITLE
feat: add url-based filtering to catalog

### DIFF
--- a/app/components/MiniAppsFilter/FilterCategoryOptions.tsx
+++ b/app/components/MiniAppsFilter/FilterCategoryOptions.tsx
@@ -13,7 +13,7 @@ const SORTED_CATEGORY_CODES: CategoryCode[] = [
 ]
 
 type FilterCategoryOptionsProps = {
-    selectedCategoryCodes: Partial<Record<CategoryCode, boolean>>
+    selectedCategoryCodes: Array<CategoryCode>
     onCategoryCodeSelectedChange: (
         categoryCode: CategoryCode,
         isSelected: boolean,
@@ -24,7 +24,7 @@ const FilterCategoryOptions = (props: FilterCategoryOptionsProps) => {
     const { selectedCategoryCodes, onCategoryCodeSelectedChange } = props
 
     const categoryOptions = SORTED_CATEGORY_CODES.map((categoryCode) => {
-        const isSelected = selectedCategoryCodes[categoryCode] === true
+        const isSelected = selectedCategoryCodes.includes(categoryCode)
         const categoryName = categoriesByCode[categoryCode].displayName
 
         return (

--- a/app/components/MiniAppsFilter/FilterCountryOptions.tsx
+++ b/app/components/MiniAppsFilter/FilterCountryOptions.tsx
@@ -13,7 +13,7 @@ const REDUCED_COUNTRY_LIST_LENGTH = 6
 
 type FilterCountryOptionsProps = {
     searchQuery: string
-    selectedCountryCodes: Partial<Record<CountryCode, boolean>>
+    selectedCountryCodes: Array<CountryCode>
     selectedRegionCode: RegionCode | undefined
     onCountryCodeSelectedChange: (
         countryCode: CountryCode,
@@ -59,7 +59,7 @@ const FilterCountryOptions = (props: FilterCountryOptionsProps) => {
         : filteredCountryCodes.slice(0, REDUCED_COUNTRY_LIST_LENGTH)
 
     const countryOptions = visibleCountryCodes.map((countryCode) => {
-        const isSelected = selectedCountryCodes[countryCode] === true
+        const isSelected = selectedCountryCodes.includes(countryCode)
         const countryName = countriesByCountryCode[countryCode].displayName
 
         return (

--- a/app/components/MiniAppsFilter/MiniAppsFilter.tsx
+++ b/app/components/MiniAppsFilter/MiniAppsFilter.tsx
@@ -1,11 +1,11 @@
 import { Button, Dialog, Icon, Input, Text } from "@fedibtc/ui"
 import { useCallback, useEffect, useState } from "react"
+import { useMiniAppsFilterURLState } from "../../hooks/useMiniAppsFilterURLState"
 import { categoriesByCode, CategoryCode } from "../../lib/categories"
 import {
     countriesByCountryCode,
     CountryCode,
     isCountryInRegion,
-    RegionCode,
     regionsByRegionCode,
 } from "../../lib/countries"
 import { Mod } from "../../lib/schemas"
@@ -19,38 +19,34 @@ import FilterRegionOptions from "./FilterRegionOptions"
 type MiniAppsFilterProps = {
     allMiniApps: Mod[]
     onFilteredListChange: (filteredMiniApps: Mod[] | null) => void
-    onFilterSearchChange: (search: string) => void
 }
 
 const MiniAppsFilter = (props: MiniAppsFilterProps) => {
-    const { allMiniApps, onFilteredListChange, onFilterSearchChange } = props
-
+    const { allMiniApps, onFilteredListChange } = props
     const { isMobile } = useViewport()
 
-    const [miniAppSearch, setMiniAppSearch] = useState<string>("")
-    const [isModalOpen, setModalOpen] = useState<boolean>(false)
-    const [selectedRegionCode, setSelectedRegionCode] = useState<
-        RegionCode | undefined
-    >(undefined)
-    const [selectedCountryCodes, setSelectedCountryCodes] = useState<
-        Partial<Record<CountryCode, boolean>>
-    >({})
-    const [selectedCategoryCodes, setSelectedCategoryCodes] = useState<
-        Partial<Record<CategoryCode, boolean>>
-    >({})
+    const {
+        search: miniAppSearch,
+        setSearch: setMiniAppSearch,
+        region: selectedRegionCode,
+        setRegion: setSelectedRegionCode,
+        countries: selectedCountryCodes,
+        toggleCountry: toggleCountryCode,
+        categories: selectedCategoryCodes,
+        toggleCategory: toggleCategoryCode,
+        resetFilters,
+        hasActiveFilters,
+    } = useMiniAppsFilterURLState()
 
+    const [isModalOpen, setModalOpen] = useState<boolean>(false)
     const [countrySearch, setCountrySearch] = useState<string>("")
 
-    const hasRegionFilter = selectedRegionCode !== undefined
-    const hasCountryFilter = Object.values(selectedCountryCodes).some(
-        (isEnabled) => isEnabled,
-    )
-    const hasCategoryFilter = Object.values(selectedCategoryCodes).some(
-        (isEnabled) => isEnabled,
-    )
+    const hasCountryFilter = selectedCountryCodes.length > 0
+    const hasCategoryFilter = selectedCategoryCodes.length > 0
 
     const matchesSelectedRegion = useCallback(
         (miniApp: Mod) => {
+            const hasRegionFilter = selectedRegionCode !== undefined
             const matchesGlobal =
                 selectedRegionCode === "GLOBAL" &&
                 miniApp.supportedCountryCodes.length === 0
@@ -58,19 +54,19 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
             const isInRegion =
                 selectedRegionCode !== undefined &&
                 miniApp.supportedCountryCodes.some((countryCode) => {
-                    isCountryInRegion(countryCode, selectedRegionCode)
+                    return isCountryInRegion(countryCode, selectedRegionCode)
                 })
 
             return !hasRegionFilter || matchesGlobal || isInRegion
         },
-        [hasRegionFilter, selectedRegionCode],
+        [selectedRegionCode],
     )
 
     const matchesSelectedCountries = useCallback(
         (miniApp: Mod) => {
             const matchesCountry = miniApp.supportedCountryCodes.some(
                 (countryCode) => {
-                    return selectedCountryCodes[countryCode] === true
+                    return selectedCountryCodes.includes(countryCode)
                 },
             )
 
@@ -81,8 +77,9 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
 
     const matchesSelectedCategories = useCallback(
         (miniApp: Mod) => {
-            const matchesCategory =
-                selectedCategoryCodes[miniApp.categoryCode] === true
+            const matchesCategory = selectedCategoryCodes.includes(
+                miniApp.categoryCode,
+            )
 
             return !hasCategoryFilter || matchesCategory
         },
@@ -111,78 +108,45 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
         [miniAppSearch],
     )
 
-    const hasModalFiltersApplied =
-        hasRegionFilter || hasCountryFilter || hasCategoryFilter
-
     const filterDescriptions = []
-    if (hasRegionFilter) {
+    if (selectedRegionCode) {
         filterDescriptions.push(
             `Region: ${regionsByRegionCode[selectedRegionCode].displayName}`,
         )
     }
 
     if (hasCountryFilter) {
-        const countries = []
-
-        for (const entry of Object.entries(selectedCountryCodes)) {
-            const [countryCode, isEnabled] = entry as [CountryCode, boolean]
-            if (isEnabled) {
-                countries.push(countriesByCountryCode[countryCode].displayName)
-            }
-        }
-
+        const countries = selectedCountryCodes.map(
+            (countryCode) => countriesByCountryCode[countryCode].displayName,
+        )
         filterDescriptions.push(`Country: ${countries.join(", ")}`)
     }
 
     if (hasCategoryFilter) {
-        const categories = []
-
-        for (const entry of Object.entries(selectedCategoryCodes)) {
-            const [categoryCode, isEnabled] = entry as [CategoryCode, boolean]
-            if (isEnabled) {
-                categories.push(categoriesByCode[categoryCode].displayName)
-            }
-        }
-
+        const categories = selectedCategoryCodes.map(
+            (categoryCode) => categoriesByCode[categoryCode].displayName,
+        )
         filterDescriptions.push(`Category: ${categories.join(", ")}`)
     }
 
     const filterDescriptionText = filterDescriptions.join("; ")
 
-    const resetModalFilters = () => {
-        setCountrySearch("")
-        setSelectedRegionCode(undefined)
-        setSelectedCountryCodes({})
-        setSelectedCategoryCodes({})
-    }
-
     const setCountryCodeSelected = (
         countryCode: CountryCode,
         isSelected: boolean,
     ) => {
-        setSelectedCountryCodes((prev) => {
-            return {
-                ...prev,
-                [countryCode]: isSelected,
-            }
-        })
+        toggleCountryCode(countryCode, isSelected)
     }
 
     const setCategoryCodeSelected = (
         categoryCode: CategoryCode,
         isSelected: boolean,
     ) => {
-        setSelectedCategoryCodes((prev) => {
-            return {
-                ...prev,
-                [categoryCode]: isSelected,
-            }
-        })
+        toggleCategoryCode(categoryCode, isSelected)
     }
 
     useEffect(() => {
-        const hasFiltersApplied =
-            hasModalFiltersApplied || miniAppSearch.length > 0
+        const hasFiltersApplied = hasActiveFilters || miniAppSearch.length > 0
 
         if (hasFiltersApplied) {
             const filteredMiniApps: Mod[] = Object.values(allMiniApps).filter(
@@ -200,23 +164,17 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
         } else {
             onFilteredListChange(null)
         }
-        // Do NOT add `onFilterSearchChange` or `allMiniApps` as dependencies
+        // Do NOT add `allMiniApps` as dependency
         // or you will get an infinite useEffect loop
         // eslint-disable-next-line
     }, [
-        hasModalFiltersApplied,
+        hasActiveFilters,
         miniAppSearch,
         matchesSelectedRegion,
         matchesSelectedCountries,
         matchesSelectedCategories,
         matchesSearch,
     ])
-
-    useEffect(() => {
-        onFilterSearchChange(miniAppSearch)
-        // Do NOT add `onFilterSearchChange` as dependency
-        // eslint-disable-next-line
-    }, [miniAppSearch])
 
     return (
         <Flex col width="full">
@@ -236,7 +194,7 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
                 >
                     <Icon icon="IconFilter" size="sm" />
 
-                    {hasModalFiltersApplied && (
+                    {hasActiveFilters && (
                         <Icon
                             icon="IconCircleFilled"
                             size="xxs"
@@ -270,10 +228,10 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
                                     Filter
                                 </Text>
 
-                                {hasModalFiltersApplied && (
+                                {hasActiveFilters && (
                                     <Text
                                         className="text-blue"
-                                        onClick={resetModalFilters}
+                                        onClick={resetFilters}
                                         data-testid="filter-reset"
                                     >
                                         Reset

--- a/app/content.tsx
+++ b/app/content.tsx
@@ -10,6 +10,7 @@ import Flex from "./components/flex"
 import CatalogItem from "./components/item"
 import MiniAppGroup from "./components/miniAppGroup"
 import { useViewport } from "./components/viewport-provider"
+import { useMiniAppsFilterURLState } from "./hooks/useMiniAppsFilterURLState"
 import { Mod } from "./lib/schemas"
 import { GroupContent } from "./page"
 
@@ -25,11 +26,11 @@ export default function PageContent({
     const toast = useToast()
     const { isMobile } = useViewport()
 
+    const { search: filterSearch } = useMiniAppsFilterURLState()
     const [fediApiAvailable, setFediApiAvailable] = useState<boolean>(false)
     const [installedMiniApps, setInstalledMiniApps] = useState<
         { url: string }[]
     >([])
-    const [filterSearch, setFilterSearch] = useState<string>("")
     const [filteredMiniApps, setFilteredMiniApps] = useState<Mod[] | null>(null)
     const [moreDetailsApp, setMoreDetailsApp] = useState<Mod | undefined>(
         undefined,
@@ -171,7 +172,6 @@ export default function PageContent({
                 <MiniAppsFilter
                     allMiniApps={Object.values(allMiniAppsById)}
                     onFilteredListChange={setFilteredMiniApps}
-                    onFilterSearchChange={setFilterSearch}
                 />
             </Flex>
 

--- a/app/hooks/useMiniAppsFilterURLState.ts
+++ b/app/hooks/useMiniAppsFilterURLState.ts
@@ -1,0 +1,169 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { CategoryCode } from "../lib/categories"
+import { CountryCode, RegionCode } from "../lib/countries"
+
+const SEARCH_DEBOUNCE_MS = 500
+
+export type MiniAppsFilterState = {
+    search: string
+    region: RegionCode | undefined
+    countries: Array<CountryCode>
+    categories: Array<CategoryCode>
+}
+
+export function useMiniAppsFilterURLState() {
+    const searchParams = useSearchParams()
+    const router = useRouter()
+
+    const urlState: MiniAppsFilterState = useMemo(() => {
+        const search = searchParams.get("search") ?? ""
+        const region = (searchParams.get("region") as RegionCode) || undefined
+        const countriesParam = searchParams.get("countries")
+        const categoriesParam = searchParams.get("categories")
+
+        const countries: Array<CountryCode> = countriesParam
+            ? (countriesParam.split(",").filter(Boolean) as Array<CountryCode>)
+            : []
+
+        const categories: Array<CategoryCode> = categoriesParam
+            ? (categoriesParam
+                  .split(",")
+                  .filter(Boolean) as Array<CategoryCode>)
+            : []
+
+        return {
+            search,
+            region,
+            countries,
+            categories,
+        }
+    }, [searchParams])
+
+    // Local state for search input
+    const [searchInput, setSearchInput] = useState(urlState.search)
+    const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+    const setSearch = useCallback(
+        (value: string) => {
+            setSearchInput(value)
+
+            if (debounceTimeoutRef.current) {
+                clearTimeout(debounceTimeoutRef.current)
+            }
+
+            debounceTimeoutRef.current = setTimeout(() => {
+                const url = new URL(window.location.href)
+                if (value.length > 0) {
+                    url.searchParams.set("search", value)
+                } else {
+                    url.searchParams.delete("search")
+                }
+                router.replace(url.pathname + url.search, { scroll: false })
+            }, SEARCH_DEBOUNCE_MS)
+        },
+        [router],
+    )
+
+    const setRegion = useCallback(
+        (region: RegionCode | undefined) => {
+            const url = new URL(window.location.href)
+            if (region) {
+                url.searchParams.set("region", region)
+            } else {
+                url.searchParams.delete("region")
+            }
+            router.replace(url.pathname + url.search, { scroll: false })
+        },
+        [router],
+    )
+
+    const toggleCountry = useCallback(
+        (countryCode: CountryCode, enabled: boolean) => {
+            const newCountries = enabled
+                ? Array.from(new Set([...urlState.countries, countryCode]))
+                : urlState.countries.filter((c) => c !== countryCode)
+
+            const url = new URL(window.location.href)
+            if (newCountries.length > 0) {
+                url.searchParams.set("countries", newCountries.join(","))
+            } else {
+                url.searchParams.delete("countries")
+            }
+            router.replace(url.pathname + url.search, { scroll: false })
+        },
+        [urlState.countries, router],
+    )
+
+    const toggleCategory = useCallback(
+        (categoryCode: CategoryCode, enabled: boolean) => {
+            const newCategories = enabled
+                ? Array.from(new Set([...urlState.categories, categoryCode]))
+                : urlState.categories.filter((c) => c !== categoryCode)
+
+            const url = new URL(window.location.href)
+            if (newCategories.length > 0) {
+                url.searchParams.set("categories", newCategories.join(","))
+            } else {
+                url.searchParams.delete("categories")
+            }
+            router.replace(url.pathname + url.search, { scroll: false })
+        },
+        [urlState.categories, router],
+    )
+
+    const resetFilters = useCallback(() => {
+        const url = new URL(window.location.href)
+        url.searchParams.delete("region")
+        url.searchParams.delete("countries")
+        url.searchParams.delete("categories")
+        // Keep search when resetting filters
+        router.replace(url.pathname + url.search, { scroll: false })
+    }, [router])
+
+    const resetAll = useCallback(() => {
+        setSearchInput("")
+        const url = new URL(window.location.href)
+        url.searchParams.delete("search")
+        url.searchParams.delete("region")
+        url.searchParams.delete("countries")
+        url.searchParams.delete("categories")
+        router.replace(url.pathname + url.search, { scroll: false })
+    }, [router])
+
+    // Cleanup timeout on unmount
+    useEffect(() => {
+        return () => {
+            if (debounceTimeoutRef.current) {
+                clearTimeout(debounceTimeoutRef.current)
+            }
+        }
+    }, [])
+
+    const hasActiveFilters =
+        urlState.region !== undefined ||
+        urlState.countries.length > 0 ||
+        urlState.categories.length > 0
+
+    const hasActiveSearch = urlState.search.length > 0
+
+    return {
+        // State - use local searchInput for immediate UI updates
+        search: searchInput,
+        region: urlState.region,
+        countries: urlState.countries,
+        categories: urlState.categories,
+        // Actions
+        setSearch,
+        setRegion,
+        toggleCountry,
+        toggleCategory,
+        resetFilters,
+        resetAll,
+        // Computed
+        hasActiveFilters,
+        hasActiveSearch,
+    }
+}

--- a/e2e/browser-mode/url-filtering.spec.ts
+++ b/e2e/browser-mode/url-filtering.spec.ts
@@ -1,0 +1,240 @@
+import { expect, test } from "../fixtures/base"
+import { filterOptionTestId } from "../helpers/test-ids"
+
+test.describe("Browser Mode - URL-based Filtering", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+    })
+
+    test("search updates URL with search param after debounce", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("Boltz")
+
+        // Wait for the 500ms debounce to update the URL
+        await page.waitForURL(/[?&]search=Boltz/, { timeout: 15_000 })
+        expect(page.url()).toContain("search=Boltz")
+    })
+
+    test("category filter updates URL", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+
+        await page
+            .getByTestId(filterOptionTestId("category", "AI & Chatbots"))
+            .click()
+        await catalogPage.closeFilterModal()
+
+        await expect(page).toHaveURL(/[?&]categories=ai/)
+    })
+
+    test("region filter updates URL", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Region & Country")
+
+        await page.getByTestId(filterOptionTestId("region", "Global")).click()
+        await catalogPage.closeFilterModal()
+
+        await expect(page).toHaveURL(/[?&]region=GLOBAL/)
+    })
+
+    test("navigating to URL with search param shows filtered results", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?search=Boltz", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(catalogPage.getSearchInput()).toHaveValue("Boltz")
+    })
+
+    test("navigating to URL with category param shows filtered results", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?categories=ai", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "Category: AI & Chatbots",
+        )
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(catalogPage.getFilterIndicator()).toBeVisible()
+    })
+
+    test("navigating to URL with region param shows filtered results", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?region=GLOBAL", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "Region: Global",
+        )
+        await expect(catalogPage.getFilterIndicator()).toBeVisible()
+    })
+
+    test("navigating to URL with combined params", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?search=bitcoin&categories=ai", {
+            waitUntil: "domcontentloaded",
+        })
+        await catalogPage.waitForCatalogReady()
+
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "Category: AI & Chatbots",
+        )
+        await expect(catalogPage.getSearchInput()).toHaveValue("bitcoin")
+    })
+
+    test("filters persist across page reload", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+
+        await page
+            .getByTestId(filterOptionTestId("category", "AI & Chatbots"))
+            .click()
+        await catalogPage.closeFilterModal()
+
+        await expect(page).toHaveURL(/[?&]categories=ai/)
+
+        // Reload the page
+        await page.reload({ waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        // Filter should still be applied
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "Category: AI & Chatbots",
+        )
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(catalogPage.getFilterIndicator()).toBeVisible()
+    })
+
+    test("reset clears filter URL params", async ({ page, catalogPage }) => {
+        await page.goto("/?categories=ai&region=GLOBAL", {
+            waitUntil: "domcontentloaded",
+        })
+        await catalogPage.waitForCatalogReady()
+
+        await expect(catalogPage.getFilterIndicator()).toBeVisible()
+
+        await catalogPage.openFilterModal()
+        await page.getByTestId("filter-reset").click()
+        await catalogPage.closeFilterModal()
+
+        // URL should no longer have filter params
+        await expect(page).not.toHaveURL(/categories=/)
+        await expect(page).not.toHaveURL(/region=/)
+        await expect(catalogPage.getFilterIndicator()).not.toBeVisible()
+    })
+
+    test("clearing search removes search param from URL", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?search=Boltz", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        await catalogPage.getSearchInput().fill("")
+
+        // Wait for debounce to clear the URL param
+        await page.waitForURL((url) => !url.searchParams.has("search"), {
+            timeout: 15_000,
+        })
+        expect(page.url()).not.toContain("search=")
+    })
+
+    test("reset keeps search param when only clearing modal filters", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?search=bitcoin&categories=ai", {
+            waitUntil: "domcontentloaded",
+        })
+        await catalogPage.waitForCatalogReady()
+
+        await catalogPage.openFilterModal()
+        await page.getByTestId("filter-reset").click()
+        await catalogPage.closeFilterModal()
+
+        // Search should still be in URL, category should be gone
+        expect(page.url()).toContain("search=bitcoin")
+        expect(page.url()).not.toContain("categories=")
+    })
+
+    test("multiple categories in URL are comma-separated", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+
+        await page
+            .getByTestId(filterOptionTestId("category", "AI & Chatbots"))
+            .click()
+        await page.getByTestId(filterOptionTestId("category", "Misc")).click()
+        await catalogPage.closeFilterModal()
+
+        // Comma may be URL-encoded as %2C
+        await expect(page).toHaveURL(/categories=ai(%2C|,)misc/)
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "AI & Chatbots",
+        )
+        await expect(catalogPage.getFilterDescription()).toContainText("Misc")
+    })
+
+    test("country filter updates URL and shows filtered results", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?countries=IN", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "Country: India",
+        )
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(catalogPage.getFilterIndicator()).toBeVisible()
+    })
+
+    test("modal checkboxes reflect URL filter state", async ({
+        page,
+        catalogPage,
+    }) => {
+        await page.goto("/?categories=ai", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+
+        // AI & Chatbots checkbox should be checked
+        const aiOption = page.getByTestId(
+            filterOptionTestId("category", "AI & Chatbots"),
+        )
+        await expect(
+            aiOption.getByRole("checkbox", { checked: true }),
+        ).toBeVisible()
+
+        // Misc checkbox should NOT be checked
+        const miscOption = page.getByTestId(
+            filterOptionTestId("category", "Misc"),
+        )
+        await expect(
+            miscOption.getByRole("checkbox", { checked: false }),
+        ).toBeVisible()
+    })
+})


### PR DESCRIPTION
Addresses https://github.com/fedibtc/fedi/issues/10099

This PR updates the filtering logic such that the filter state is stored in the URL.

For the search input, there is a 500ms debounce delay after you stop typing before the URL is updated.

I had some assistance writing this PR with Kimi 2.5 + Opencode. There were some hiccups and bad practices but I ironed them out for the most part.

## Testing

- Confirm that typing in the search input updates the URL 500ms after you stop typing
- Confirm that reloading the page lands you on the same results
- Confirm that using the filter modal updates the URL
- Refresh, close, and paste the URL with filter params. You should get filtered search results
- Filter updates should not trigger a full page reload