### PR TITLE
feat: add Bhartiya Bitcoin

### DIFF
--- a/mods/misc/bhartiya-bitcoin/meta.json
+++ b/mods/misc/bhartiya-bitcoin/meta.json
@@ -1,0 +1,10 @@
+{
+    "name": "Bhartiya Bitcoin",
+    "id": "bhartiya-bitcoin",
+    "url": "https://bhartiyabitcoin.com/",
+    "iconUrl": "https://bhartiyabitcoin.com/wp-content/uploads/2026/05/cropped-Bhartiya-Logo-Dark-1-192x192.png",
+    "description": "Digital platform delivering Bitcoin education in 13 Indian languages",
+    "extendedDescription": "We are a digital education platform promoting Bitcoin awareness across India. We create and share Bitcoin educational content in 13 Indian languages on Instagram, X (Twitter), YouTube, and Rumble to make Bitcoin knowledge accessible to people across the country. We have a team of translators and video editors, hence we are open to new projects related to Bitcoin awareness.",
+    "supportedCountryCodes": ["IN"],
+    "keywords": ["bitcoininindia", "bhartiyabitcoin", "cryptolearningcentre", "60daysofbtc", "btcrevolutioninindia"]
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "sgx-remit",
     "use-bitcoin",
     "exolix",
     "banxaas",
     "retiro-bitcoin",
-    "bitmol"
+    "bitmol",
+    "bhartiya-bitcoin"
   ]
 }


### PR DESCRIPTION
## Description

- catalog has no "education" category, so it lands in misc next to the other education apps (Mi Primer Bitcoin, HRF, Bitcoin Only)
- submitted icon was a google drive viewer link to a 16:9 banner, unusable in the square grid, so it uses the site's own 192x192 favicon