### PR TITLE
feat: add Bhartiya Bitcoin + Smash 54052

### DIFF
--- a/mods/cash-in-cash-out/smash-54052/meta.json
+++ b/mods/cash-in-cash-out/smash-54052/meta.json
@@ -1,0 +1,10 @@
+{
+    "name": "Smash 54052",
+    "id": "smash-54052",
+    "url": "https://smash.54052.co.za",
+    "iconUrl": "https://54052.co.za/static/img/54052.svg",
+    "description": "smash buy Bitcoin and get it delivered to your wallet of choice",
+    "extendedDescription": "Use the 54052.co.za service to securely and conveniently smash buy Bitcoin. Add a beneficiary and pay from your banking app when it suits you, or load up an instant PayShap request for convenient, instant settlement.",
+    "supportedCountryCodes": ["ZA"],
+    "keywords": ["smash", "buy", "bitcoin"]
+}

--- a/mods/misc/bhartiya-bitcoin/meta.json
+++ b/mods/misc/bhartiya-bitcoin/meta.json
@@ -1,0 +1,10 @@
+{
+    "name": "Bhartiya Bitcoin",
+    "id": "bhartiya-bitcoin",
+    "url": "https://bhartiyabitcoin.com/",
+    "iconUrl": "https://bhartiyabitcoin.com/wp-content/uploads/2026/05/cropped-Bhartiya-Logo-Dark-1-192x192.png",
+    "description": "Digital platform delivering Bitcoin education in 13 Indian languages",
+    "extendedDescription": "We are a digital education platform promoting Bitcoin awareness across India. We create and share Bitcoin educational content in 13 Indian languages on Instagram, X (Twitter), YouTube, and Rumble to make Bitcoin knowledge accessible to people across the country. We have a team of translators and video editors, hence we are open to new projects related to Bitcoin awareness.",
+    "supportedCountryCodes": ["IN"],
+    "keywords": ["bitcoininindia", "bhartiyabitcoin", "cryptolearningcentre", "60daysofbtc", "btcrevolutioninindia"]
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "sgx-remit",
     "use-bitcoin",
     "exolix",
     "banxaas",
     "retiro-bitcoin",
-    "bitmol"
+    "bitmol",
+    "bhartiya-bitcoin"
   ]
 }

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "use-bitcoin",
     "exolix",
     "banxaas",
     "retiro-bitcoin",
     "bitmol",
-    "bhartiya-bitcoin"
+    "bhartiya-bitcoin",
+    "smash-54052"
   ]
 }


### PR DESCRIPTION
adds two mini apps:

- **Bhartiya Bitcoin** (misc) - bitcoin education in 13 indian languages. no education category exists, so misc alongside mi-primer-bitcoin/hrf/bitcoin-only. icon uses the site's square favicon since the submitted google drive link was a 16:9 banner viewer page
- **Smash 54052** (cash-in-cash-out) - south african service to buy bitcoin and auto-deliver to a wallet. description trimmed to fit the 72 char limit
