### PR TITLE
chore: remove Docstr and Kanbanstr

### DIFF
--- a/mods/productivities/docstr/meta.json
+++ b/mods/productivities/docstr/meta.json
@@ -1,7 +1,0 @@
-{
-  "name": "Docstr",
-  "id": "docstr",
-  "url": "https://docstr.app",
-  "iconUrl": "https://docstr.app/logo.svg",
-  "description": "Create a document"
-}

--- a/mods/productivities/kanbanstr/meta.json
+++ b/mods/productivities/kanbanstr/meta.json
@@ -1,7 +1,0 @@
-{
-  "name": "Kanbanstr",
-  "id": "kanbanstr",
-  "url": "https://www.kanbanstr.com/",
-  "iconUrl": "https://www.kanbanstr.com/favicon.ico",
-  "description": "Collaborative Kanban Board"
-}


### PR DESCRIPTION
Removes two mini apps with dead links, found during a catalog link audit:

- **Docstr** (`https://docstr.app`) — domain no longer resolves (DNS NXDOMAIN), the site is gone.
- **Kanbanstr** (`https://www.kanbanstr.com/`) — returns 404 "Site not found · GitHub Pages"; the deployment was removed.

Both lived under `mods/productivities/` and aren't referenced anywhere else (e.g. `newMods.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)