### PR TITLE
chore: remove Docstr and Kanbanstr from production

### DIFF
--- a/mods/productivities/docstr/meta.json
+++ b/mods/productivities/docstr/meta.json
@@ -1,7 +1,0 @@
-{
-  "name": "Docstr",
-  "id": "docstr",
-  "url": "https://docstr.app",
-  "iconUrl": "https://docstr.app/logo.svg",
-  "description": "Create a document"
-}

--- a/mods/productivities/kanbanstr/meta.json
+++ b/mods/productivities/kanbanstr/meta.json
@@ -1,7 +1,0 @@
-{
-  "name": "Kanbanstr",
-  "id": "kanbanstr",
-  "url": "https://www.kanbanstr.com/",
-  "iconUrl": "https://www.kanbanstr.com/favicon.ico",
-  "description": "Collaborative Kanban Board"
-}


### PR DESCRIPTION
- Same change as https://github.com/fedibtc/catalog/pull/100, deploying to production.