### PR TITLE
feat: add Satoshi Runner

### DIFF
--- a/mods/games/satoshi-runner/meta.json
+++ b/mods/games/satoshi-runner/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "Satoshi Runner",
+    "id": "satoshi-runner",
+    "url": "https://sat-runner.vercel.app/",
+    "iconUrl": "https://sat-runner.vercel.app/icon.png",
+    "description": "Endless runner game - die once, pay 1 sat to keep running forever.",
+    "extendedDescription": "A never-ending neon runner built for the Lightning Network. Jump and slide through an endless synthwave landscape. The moment you crash, the run ends. The only way back in is paying 1 satoshi, settled instantly against your own node via Nostr Wallet Connect (NIP-47). No accounts, no ads, no free retries - just a tiny real Bitcoin payment to keep running.",
+    "keywords": []
+}

--- a/mods/games/satoshi-runner/meta.json
+++ b/mods/games/satoshi-runner/meta.json
@@ -5,5 +5,10 @@
     "iconUrl": "https://sat-runner.vercel.app/icon.png",
     "description": "Endless runner game - die once, pay 1 sat to keep running forever.",
     "extendedDescription": "A never-ending neon runner built for the Lightning Network. Jump and slide through an endless synthwave landscape. The moment you crash, the run ends. The only way back in is paying 1 satoshi, settled instantly against your own node via Nostr Wallet Connect (NIP-47). No accounts, no ads, no free retries - just a tiny real Bitcoin payment to keep running.",
-    "keywords": []
+    "keywords": [
+        "game",
+        "arcade",
+        "lightning",
+        "nostr"
+    ]
 }

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "banxaas",
     "retiro-bitcoin",
     "bitmol",
     "bhartiya-bitcoin",
     "smash-54052",
-    "desiboard"
+    "desiboard",
+    "satoshi-runner"
   ]
 }


### PR DESCRIPTION
adds one mini app:

- **Satoshi Runner** (games) - lightning-powered endless runner game; crash once, pay 1 sat to keep running. Payments settle instantly against your own node via Nostr Wallet Connect (NIP-47). description trimmed to fit the 72 char limit. Added to `newMods.json` (rolling window of 6 — dropped oldest `banxaas`). App and icon links verified live (both return 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)