### PR TITLE
feat: add 2fiat

### DIFF
--- a/mods/cash-in-cash-out/2fiat/meta.json
+++ b/mods/cash-in-cash-out/2fiat/meta.json
@@ -1,0 +1,8 @@
+{
+    "name": "2fiat",
+    "id": "2fiat",
+    "url": "https://2fiat.com/",
+    "iconUrl": "https://2fiat.com/favicon.ico",
+    "description": "Anonymous No KYC credit card, reloadable, usable worldwide",
+    "keywords": []
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "banxaas",
     "retiro-bitcoin",
     "bitmol",
     "bhartiya-bitcoin",
     "smash-54052",
-    "desiboard"
+    "desiboard",
+    "2fiat"
   ]
 }


### PR DESCRIPTION
adds one mini app:

- **2fiat** (cash-in-cash-out) - anonymous no-KYC reloadable credit card, usable worldwide. Categorized as `cash-in-cash-out` (its prior placement, alongside banxaas/smash-54052) rather than the submission's `Communications` type, which only holds chat apps. Added to `newMods.json` (rolling window of 6 — dropped oldest `banxaas`). App and icon links verified live (both return 200).

Note: 2fiat was previously removed in #89/#90; this re-adds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)