### PR TITLE
feat: add Satoshi Snake + Trails Coffee

### DIFF
--- a/mods/games/satoshi-snake/meta.json
+++ b/mods/games/satoshi-snake/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "Satoshi Snake",
+    "id": "satoshi-snake",
+    "url": "https://satoshi-snake.vercel.app/",
+    "iconUrl": "https://satoshi-snake.vercel.app/icon.svg",
+    "description": "Play Snake, earn sats, and continue with Lightning",
+    "extendedDescription": "Satoshi Snake is a neon arcade Snake game with real Lightning rewards. Players earn 2 sats for every 5 points, claim their reward at game over to a Lightning address, LNURL, or BOLT11 invoice, and can pay 1 sat to continue after losing. Payments are handled through Alby Hub using Nostr Wallet Connect.",
+    "keywords": ["game", "arcade", "snake", "lightning"]
+}

--- a/mods/games/trails-coffee/meta.json
+++ b/mods/games/trails-coffee/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "Trails Coffee",
+    "id": "trails-coffee",
+    "url": "https://fedi.trailscoffee.com/",
+    "iconUrl": "https://fedi.trailscoffee.com/favicon.svg",
+    "description": "Gamify your Bitcoin community with fun challenges and rewards.",
+    "extendedDescription": "Design engaging Bitcoin experiences for your community. Create challenges, missions, and interactive activities that encourage people to learn, explore, and collaborate. Perfect for meetups, conferences, workshops, classrooms, and local communities looking to make Bitcoin education more memorable and fun.",
+    "keywords": ["game", "community", "challenges", "education"]
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "bitmol",
-    "bhartiya-bitcoin",
     "smash-54052",
     "desiboard",
     "2fiat",
-    "satoshi-runner"
+    "satoshi-runner",
+    "satoshi-snake",
+    "trails-coffee"
   ]
 }


### PR DESCRIPTION
adds two mini apps:

- **Satoshi Snake** (games) - neon arcade Snake game with real Lightning rewards; earn 2 sats per 5 points, claim payouts to a Lightning address/LNURL/BOLT11, and pay 1 sat to continue after losing (via Alby Hub + NWC).
- **Trails Coffee** (games) - gamify your Bitcoin community with challenges, missions and rewards for meetups, conferences, workshops and classrooms. Icon uses the site's own `favicon.svg` because the submitted `ibb.co` link was a dead viewer page (404).

Both added to `newMods.json` (rolling window of 6 — dropped oldest `bitmol` and `bhartiya-bitcoin`). App and icon links verified live (all return 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)