### PR TITLE
feat: add BTC Isla Map + Tapnob + Satsmarket

### DIFF
--- a/mods/cash-in-cash-out/tapnob/meta.json
+++ b/mods/cash-in-cash-out/tapnob/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "Tapnob",
+    "id": "tapnob",
+    "url": "https://www.tapnob.com/fedi",
+    "iconUrl": "https://www.tapnob.com/icons/icon-512x512.png",
+    "description": "Buy Bitcoin and convert Lightning payments to Nigerian Naira instantly",
+    "extendedDescription": "Tapnob is a Bitcoin payments platform that lets users buy Bitcoin and spend it in Nigeria. Through the Fedi mini app, users can purchase Bitcoin or send Lightning payments that are instantly converted to Naira and settled directly into Nigerian bank accounts. Tapnob provides fast settlement, transparent exchange rates, and a simple way to move between Bitcoin and local currency without requiring recipients to use Bitcoin.",
+    "keywords": ["bitcoin", "offramp", "naira", "nigeria", "lightning"]
+}

--- a/mods/misc/btc-isla-map/meta.json
+++ b/mods/misc/btc-isla-map/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "BTC Isla Map",
+    "id": "btc-isla-map",
+    "url": "https://www.btcislamap.org",
+    "iconUrl": "https://www.btcislamap.org/btcisla_logo.png",
+    "description": "BTC Isla Map of Bitcoin Accepting Merchants",
+    "extendedDescription": "Interactive web map of all Bitcoin accepting merchants within the BTC Isla circular economy (Isla Mujeres, Mexico). All merchant locations are stored and managed using BTCMap and rendered using the BTCMap API.",
+    "keywords": ["map", "merchants", "bitcoin", "mexico"]
+}

--- a/mods/spend-earn-bitcoin/satsmarket/meta.json
+++ b/mods/spend-earn-bitcoin/satsmarket/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "Satsmarket",
+    "id": "satsmarket",
+    "url": "https://satsmarket.xyz/",
+    "iconUrl": "/satsmarket.svg",
+    "description": "Lightning marketplace to buy & sell with sats, no middlemen (Indonesia)",
+    "extendedDescription": "SatsMarket is a Lightning Network-based marketplace where users can buy and sell products, services, and digital goods using sats - no banks, no middlemen, and no country restrictions. Transactions are purely peer-to-peer between buyer and seller; SatsMarket does not act as a third party in the transaction itself. Product categories include groceries, clothing, services, electronics, digital goods, food, daily necessities, books, accessories, automotive, agriculture, health, education, and arts & crafts. Sellers and buyers connect through a community group on Fedi.",
+    "keywords": ["marketplace", "lightning", "p2p", "indonesia"]
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "smash-54052",
-    "desiboard",
     "2fiat",
     "satoshi-runner",
     "satoshi-snake",
-    "trails-coffee"
+    "trails-coffee",
+    "btc-isla-map",
+    "tapnob"
   ]
 }

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "2fiat",
     "satoshi-runner",
     "satoshi-snake",
     "trails-coffee",
     "btc-isla-map",
-    "tapnob"
+    "tapnob",
+    "satsmarket"
   ]
 }

--- a/public/satsmarket.svg
+++ b/public/satsmarket.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 680" role="img">
+  <title>SatsMarket logo icon</title>
+  <desc>Orange rounded square with black border and a white Bitcoin symbol</desc>
+  <rect x="90" y="90" width="500" height="500" rx="110" ry="110" fill="#F7931A" stroke="#000000" stroke-width="22"/>
+  <text x="340" y="530" font-family="Arial Black, Impact, sans-serif" font-size="420" font-weight="900" fill="#FFFFFF" text-anchor="middle">₿</text>
+</svg>


### PR DESCRIPTION
adds three mini apps:

- **BTC Isla Map** (misc) - interactive map of Bitcoin-accepting merchants in the BTC Isla circular economy (Isla Mujeres, Mexico), rendered via the BTCMap API. Trimmed the trailing duplicate "Map" from the description. Note: the only available icon is the site's logo PNG, which is large (~7 MB) — worth swapping for an optimized version if one becomes available.
- **Tapnob** (cash-in-cash-out) - buy Bitcoin and convert Lightning payments to Nigerian Naira, settled to local bank accounts. Submitted URL had no scheme (fixed to `https://www.tapnob.com/fedi`) and the icon was a Google Drive *folder* link (replaced with the site's own `icons/icon-512x512.png`). Description trimmed to fit 72 chars.
- **Satsmarket** (spend-earn-bitcoin) - Lightning-native P2P marketplace for Indonesia; buy & sell goods and services with sats, no middlemen. The site has no image icon (its logo is a CSS-rendered ₿), so the icon is hosted in-repo at `public/satsmarket.svg` and referenced as `/satsmarket.svg` (same pattern as HRF / Sats Converter). Description trimmed to fit 72 chars.

All three added to `newMods.json` (rolling window of 6 — dropped oldest `2fiat`, `smash-54052`, `desiboard`). App and icon links verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)