### PR TITLE
feat: add LNemail

### DIFF
--- a/mods/productivities/lnemail/meta.json
+++ b/mods/productivities/lnemail/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "LNemail",
+    "id": "lnemail",
+    "url": "https://lnemail.net/",
+    "iconUrl": "https://blossom.primal.net/c0394dd3eccea8e070d4b24ed0b1300cec286203f4f51503850f47250021af78.jpg",
+    "description": "Fast Anonymous Email Accounts",
+    "extendedDescription": "Get instant disposable email addresses powered by Bitcoin Lightning Network. No personal information required - just pay with Lightning and start sending and receiving emails immediately.",
+    "keywords": ["email", "privacy", "anonymous", "lightning"]
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "smash-54052",
     "desiboard",
     "2fiat",
     "satoshi-runner",
     "satoshi-snake",
-    "trails-coffee"
+    "trails-coffee",
+    "lnemail"
   ]
 }


### PR DESCRIPTION
adds one mini app:

- **LNemail** (productivities) - fast, anonymous, disposable email accounts paid for with the Bitcoin Lightning Network; no personal information required. Added to `newMods.json` (rolling window of 6 — dropped oldest `smash-54052`). App and icon links verified live (both return 200).

Note: overlaps `newMods.json` with #108; whichever merges second may need a one-line rebase of the id list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)