### PR TITLE
feat: add Agenda Web3

### DIFF
--- a/mods/misc/agenda-web3/meta.json
+++ b/mods/misc/agenda-web3/meta.json
@@ -1,0 +1,9 @@
+{
+    "name": "Agenda Web3",
+    "id": "agenda-web3",
+    "url": "https://techcripto.com/eventos-web3/",
+    "iconUrl": "https://i0.wp.com/techcripto.com/wp-content/uploads/2025/12/cropped-techcripto-noticias-criptomoedas-tecnologia-news-web3-informacao-conteudo-1.png?fit=512%2C512&quality=75&ssl=1",
+    "description": "List of Web3 events in LATAM",
+    "extendedDescription": "Web page with a dynamic list of Web3 events across Latin America with filters for period, country, category, and type.",
+    "keywords": ["events", "web3", "latam", "calendar"]
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "smash-54052",
     "desiboard",
     "2fiat",
     "satoshi-runner",
     "satoshi-snake",
-    "trails-coffee"
+    "trails-coffee",
+    "agenda-web3"
   ]
 }


### PR DESCRIPTION
adds one mini app:

- **Agenda Web3** (misc) - dynamic list of Web3 events across Latin America, with filters for period, country, category and type. Added to `newMods.json` (rolling window of 6 — dropped oldest `smash-54052`). App and icon links verified live (both return 200).

Note: overlaps `newMods.json` with #108 and #110; whichever merges last will need a trivial one-line rebase of the id list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)