### PR TITLE
Add PeerBadge to the Mini Apps catalog

### DIFF
--- a/mods/productivities/peerbadge/meta.json
+++ b/mods/productivities/peerbadge/meta.json
@@ -1,0 +1,9 @@
+{
+  "name": "PeerBadge",
+  "id": "peerbadge",
+  "url": "https://www.peerbadge.org/",
+  "iconUrl": "https://www.peerbadge.org/assets/shield-BE3nIk3F.png",
+  "description": "Issue, collect, and verify trusted community badges",
+  "extendedDescription": "PeerBadge lets trusted community members issue cryptographically signed badges, recipients collect them, and anyone can verify them by scanning QR codes. Create a private identity or use an existing Nostr identity, exchange badges in person, and keep credential data on your device.",
+  "keywords": ["credentials", "badges", "identity", "trust", "verification", "Nostr", "QR codes", "community"]
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
+    "smash-54052",
     "desiboard",
     "2fiat",
     "satoshi-runner",
     "satoshi-snake",
-    "trails-coffee",
-    "peerbadge"
+    "trails-coffee"
   ]
 }

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "smash-54052",
     "desiboard",
     "2fiat",
     "satoshi-runner",
     "satoshi-snake",
-    "trails-coffee"
+    "trails-coffee",
+    "peerbadge"
   ]
 }


### PR DESCRIPTION
## Summary

Adds PeerBadge to the Productivity section with source-informed descriptions, search keywords, and its live app icon. The existing `newMods` rotation is left unchanged.

## Validation

Validated all 60 Mini App metadata files, confirmed IDs are unique, checked the JSON and diff formatting, and verified that the PeerBadge app and icon URLs return HTTP 200.
