### PR TITLE
feat: add PeerBadge (production)

### DIFF
--- a/mods/productivities/peerbadge/meta.json
+++ b/mods/productivities/peerbadge/meta.json
@@ -1,0 +1,9 @@
+{
+  "name": "PeerBadge",
+  "id": "peerbadge",
+  "url": "https://www.peerbadge.org/",
+  "iconUrl": "https://www.peerbadge.org/assets/shield-BE3nIk3F.png",
+  "description": "Issue, collect, and verify trusted community badges",
+  "extendedDescription": "PeerBadge lets trusted community members issue cryptographically signed badges, recipients collect them, and anyone can verify them by scanning QR codes. Create a private identity or use an existing Nostr identity, exchange badges in person, and keep credential data on your device.",
+  "keywords": ["credentials", "badges", "identity", "trust", "verification", "Nostr", "QR codes", "community"]
+}


### PR DESCRIPTION
Same change as #114, promoting PeerBadge from staging to production.

The PeerBadge metadata is byte-identical to `master`; its app and icon URLs both return HTTP 200, and the staging deployment completed successfully.
