### PR TITLE
Update PeerBadge app domain

### DIFF
--- a/mods/productivities/peerbadge/meta.json
+++ b/mods/productivities/peerbadge/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "PeerBadge",
   "id": "peerbadge",
-  "url": "https://www.peerbadge.org/",
-  "iconUrl": "https://www.peerbadge.org/assets/shield-BE3nIk3F.png",
+  "url": "https://app.peerbadge.org/",
+  "iconUrl": "https://app.peerbadge.org/assets/shield-BE3nIk3F.png",
   "description": "Issue, collect, and verify trusted community badges",
   "extendedDescription": "PeerBadge lets trusted community members issue cryptographically signed badges, recipients collect them, and anyone can verify them by scanning QR codes. Create a private identity or use an existing Nostr identity, exchange badges in person, and keep credential data on your device.",
   "keywords": ["credentials", "badges", "identity", "trust", "verification", "Nostr", "QR codes", "community"]


### PR DESCRIPTION
## Summary

Updates the PeerBadge catalog entry so its application and icon URLs use `app.peerbadge.org` instead of `www.peerbadge.org`. This directs catalog users to the current PeerBadge app domain while keeping the existing icon asset path.

## Validation

- Parsed `meta.json` with `python3 -m json.tool`
- Ran `git diff --check`
- Confirmed the updated application and icon URLs return HTTP 200
