### PR TITLE
feat: add PeerBadge (production)

### DIFF
--- a/mods/productivities/peerbadge/meta.json
+++ b/mods/productivities/peerbadge/meta.json
@@ -1,0 +1,9 @@
+{
+  "name": "PeerBadge",
+  "id": "peerbadge",
+  "url": "https://app.peerbadge.org/",
+  "iconUrl": "https://app.peerbadge.org/assets/shield-BE3nIk3F.png",
+  "description": "Issue, collect, and verify trusted community badges",
+  "extendedDescription": "PeerBadge lets trusted community members issue cryptographically signed badges, recipients collect them, and anyone can verify them by scanning QR codes. Create a private identity or use an existing Nostr identity, exchange badges in person, and keep credential data on your device.",
+  "keywords": ["credentials", "badges", "identity", "trust", "verification", "Nostr", "QR codes", "community"]
+}


### PR DESCRIPTION
## Summary

Adds the corrected PeerBadge catalog entry to production, promoting the approved staging changes from #114 and #118.

PeerBadge was previously promoted in #116 and reverted in #117 because its application domain was incorrect. The entry now uses `app.peerbadge.org` for both the application and icon URLs.

## Impact

PeerBadge will appear in the production Productivity catalog with the same metadata currently deployed from `master`.

## Validation

- Confirmed the metadata file is byte-identical to `master`
- Parsed the metadata as valid JSON
- Validated all 65 Mini App metadata IDs are unique
- Confirmed the application and icon URLs return HTTP 200
- Ran `git diff --check`
