### PR TITLE
feat: add Bitcoin Interactive Website Thailand (production)

### DIFF
--- a/mods/misc/bitcoin-interactive-website-thailand/meta.json
+++ b/mods/misc/bitcoin-interactive-website-thailand/meta.json
@@ -1,0 +1,10 @@
+{
+    "name": "Bitcoin Interactive Website Thailand",
+    "id": "bitcoin-interactive-website-thailand",
+    "url": "https://learning.chontit.win",
+    "iconUrl": "https://learning.chontit.win/main-logo.png",
+    "description": "Interactive Bitcoin-only education — learn, simulate, self-custody for Thai.",
+    "extendedDescription": "A self-directed, Bitcoin-only learning platform covering protocol fundamentals, cryptography, and market tools — from Bitcoin 101 and mining simulators to BIP-39, HD wallets, ECDSA, and the Lightning Network. Includes practical modules for trading position sizing, loan/DCA planning, and self-custody security. Currently available in Thai.",
+    "supportedCountryCodes": [],
+    "keywords": []
+}

--- a/newMods.json
+++ b/newMods.json
@@ -1,10 +1,10 @@
 {
   "newModIds": [
-    "trails-coffee",
     "btc-isla-map",
     "tapnob",
     "satsmarket",
     "lnemail",
-    "agenda-web3"
+    "agenda-web3",
+    "bitcoin-interactive-website-thailand"
   ]
 }


### PR DESCRIPTION
## Add Bitcoin Interactive Website Thailand to the Fedi Catalog

| Field | Value |
|-------|-------|
| **Name** | Bitcoin Interactive Website Thailand |
| **URL** | https://learning.chontit.win |
| **Description** | Interactive Bitcoin-only education — learn, simulate, self-custody for Thai. |
| **Category** | misc |
| **Countries** | Thailand |
| **Added by** | @Dea |

_Auto-generated by the Fedi Mini Apps dashboard when status was set to "Ready to Be Added"._