### PR TITLE
build: sync vercel/production to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,45 @@ name: Pull Request CI
 on: pull_request
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+    build:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - uses: oven-sh/setup-bun@v1
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
 
-      - name: Install Dependencies
-        run: bun i
+            - uses: cachix/install-nix-action@v30
+              with:
+                  nix_path: nixpkgs=channel:nixos-25.05
 
-      - name: Check code style
-        run: bun format:check
+            - name: Run code quality checks
+              run: nix develop -c ./scripts/check-ui-code.sh
 
-      - name: Lint
-        run: bun lint
+    e2e:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+
+            - uses: cachix/install-nix-action@v30
+              with:
+                  nix_path: nixpkgs=channel:nixos-25.05
+
+            - name: Install dependencies
+              run: nix develop -c bun install
+
+            - name: Install Playwright Browsers
+              run: nix develop -c bunx playwright install --with-deps chromium
+
+            - name: Run E2E Tests
+              run: nix develop -c bun test:e2e
+              env:
+                  CI: true
+
+            - uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[css]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
+}

--- a/app/components/FilteredMiniAppsList.tsx
+++ b/app/components/FilteredMiniAppsList.tsx
@@ -36,7 +36,11 @@ const FilteredMiniAppsList = (props: FilteredMiniAppsListProps) => {
     } else {
         return (
             <Flex col gap={4} p={4} width="full" className="max-w-[1200px]">
-                <Text variant="h2" weight="medium">
+                <Text
+                    variant="h2"
+                    weight="medium"
+                    data-testid="filtered-results-heading"
+                >
                     {miniAppElements.length} Filtered{" "}
                     {pluralize(miniAppElements.length, "Result")}
                 </Text>

--- a/app/components/MiniAppDetails.tsx
+++ b/app/components/MiniAppDetails.tsx
@@ -1,6 +1,7 @@
 import { Button, Icon, Text } from "@fedibtc/ui"
 import { useEffect, useState } from "react"
 import QRCode from "react-qr-code"
+import { miniAppTestId } from "../../e2e/helpers/test-ids"
 import { categoriesByCode } from "../lib/categories"
 import privacyPolicyUrl from "../lib/privacyPolicyUrl"
 import { Mod } from "../lib/schemas"
@@ -30,6 +31,8 @@ const MiniAppDetails = (props: MiniAppDetails) => {
         setIsInstalling(false)
     }, [miniApp])
 
+    const detailsTestId = `${miniAppTestId(miniApp.name)}-details`
+
     const handleInstallClick = async () => {
         setIsInstalling(true)
 
@@ -41,7 +44,7 @@ const MiniAppDetails = (props: MiniAppDetails) => {
     }
 
     return (
-        <div className="h-full w-full">
+        <div className="h-full w-full" data-testid={detailsTestId}>
             {showingQrCode ? (
                 <Flex
                     align="center"
@@ -49,6 +52,7 @@ const MiniAppDetails = (props: MiniAppDetails) => {
                     height="full"
                     width="full"
                     className={`${isMobile ? "bg-black" : ""}`}
+                    data-testid={`${detailsTestId}-qr-view`}
                 >
                     <Icon
                         onClick={() => setShowingQrCode(false)}
@@ -56,6 +60,7 @@ const MiniAppDetails = (props: MiniAppDetails) => {
                         width={32}
                         height={32}
                         className={`${isMobile ? "bg-black text-white" : "bg-white text-black"} absolute top-4 right-4 cursor-pointer`}
+                        data-testid={`${detailsTestId}-qr-close`}
                     />
 
                     <Flex
@@ -95,6 +100,7 @@ const MiniAppDetails = (props: MiniAppDetails) => {
                                     loading={isInstalling}
                                     variant="secondary"
                                     onClick={handleInstallClick}
+                                    data-testid={`${detailsTestId}-${isInstalled ? "added" : "add"}`}
                                 >
                                     {isInstalled ? "Added" : "Add"}
                                 </Button>
@@ -105,6 +111,7 @@ const MiniAppDetails = (props: MiniAppDetails) => {
                                 align="center"
                                 justify="center"
                                 className="p-2 rounded-full cursor-pointer border border-extraLightGrey border-solid"
+                                data-testid={`${detailsTestId}-qr-open`}
                             >
                                 <Icon
                                     icon="IconQrcode"
@@ -118,12 +125,19 @@ const MiniAppDetails = (props: MiniAppDetails) => {
                             align="center"
                             justify="between"
                             className="py-1 px-4 rounded-xl border border-extraLightGrey cursor-pointer border-solid"
+                            data-testid={`${detailsTestId}-url`}
                         >
                             <Text variant="caption" className="text-gray-600">
                                 {miniApp.url}
                             </Text>
 
-                            <Flex gap={2} align="center" p={2} onClick={onCopy}>
+                            <Flex
+                                gap={2}
+                                align="center"
+                                p={2}
+                                onClick={onCopy}
+                                data-testid={`${detailsTestId}-copy`}
+                            >
                                 <Icon icon="IconCopy" />
                                 <Text weight="medium" variant="caption">
                                     Copy
@@ -144,6 +158,7 @@ const MiniAppDetails = (props: MiniAppDetails) => {
                                         setViewMoreDescription((prev) => !prev)
                                     }
                                     className="cursor-pointer"
+                                    data-testid={`${detailsTestId}-toggle-description`}
                                 >
                                     <Text>
                                         View{" "}
@@ -198,6 +213,7 @@ const MiniAppDetails = (props: MiniAppDetails) => {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="w-fit"
+                            data-testid={`${detailsTestId}-privacy-policy`}
                         >
                             <Text
                                 variant="caption"

--- a/app/components/MiniAppsFilter/FilterCategoryOptions.tsx
+++ b/app/components/MiniAppsFilter/FilterCategoryOptions.tsx
@@ -1,4 +1,5 @@
 import { categoriesByCode, CategoryCode } from "@/app/lib/categories"
+import { filterOptionTestId } from "@/e2e/helpers/test-ids"
 import { Checkbox, Text } from "@fedibtc/ui"
 import Flex from "../flex"
 
@@ -33,6 +34,7 @@ const FilterCategoryOptions = (props: FilterCategoryOptionsProps) => {
                 onClick={() =>
                     onCategoryCodeSelectedChange(categoryCode, !isSelected)
                 }
+                data-testid={filterOptionTestId("category", categoryName)}
             >
                 <Checkbox checked={isSelected} />
 

--- a/app/components/MiniAppsFilter/FilterCountryOptions.tsx
+++ b/app/components/MiniAppsFilter/FilterCountryOptions.tsx
@@ -4,6 +4,7 @@ import {
     countryCodes,
     RegionCode,
 } from "@/app/lib/countries"
+import { filterOptionTestId } from "@/e2e/helpers/test-ids"
 import { Checkbox, Text } from "@fedibtc/ui"
 import { useState } from "react"
 import Flex from "../flex"
@@ -68,6 +69,7 @@ const FilterCountryOptions = (props: FilterCountryOptionsProps) => {
                 onClick={() =>
                     onCountryCodeSelectedChange(countryCode, !isSelected)
                 }
+                data-testid={filterOptionTestId("country", countryName)}
             >
                 <Checkbox checked={isSelected} />
 
@@ -95,6 +97,7 @@ const FilterCountryOptions = (props: FilterCountryOptionsProps) => {
                     <Text
                         className="font-bold"
                         onClick={() => setShowingAllCountries(true)}
+                        data-testid="country-view-more"
                     >
                         View more
                     </Text>

--- a/app/components/MiniAppsFilter/FilterRegionOptions.tsx
+++ b/app/components/MiniAppsFilter/FilterRegionOptions.tsx
@@ -3,6 +3,7 @@ import {
     regionCodes,
     regionsByRegionCode,
 } from "@/app/lib/countries"
+import { filterOptionTestId } from "@/e2e/helpers/test-ids"
 import { Button, Text } from "@fedibtc/ui"
 import Flex from "../flex"
 
@@ -46,6 +47,7 @@ const FilterRegionOptions = (props: FilterRegionOptionsProps) => {
                 size="sm"
                 className={`${isSelected ? "bg-gray-500 text-white" : "bg-gray-100"}`}
                 onClick={() => handleRegionCodeClick(regionCode)}
+                data-testid={filterOptionTestId("region", regionName)}
             >
                 <Text className="text-nowrap font-bold">{regionName}</Text>
             </Button>

--- a/app/components/MiniAppsFilter/MiniAppsFilter.tsx
+++ b/app/components/MiniAppsFilter/MiniAppsFilter.tsx
@@ -184,9 +184,14 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
                     value={miniAppSearch}
                     onChange={(e) => setMiniAppSearch(e.currentTarget.value)}
                     placeholder="Search Mini Apps or keywords"
+                    data-testid="catalog-search-input"
                 />
 
-                <div className="relative" onClick={() => setModalOpen(true)}>
+                <div
+                    className="relative"
+                    onClick={() => setModalOpen(true)}
+                    data-testid="filter-trigger"
+                >
                     <Icon icon="IconFilter" size="sm" />
 
                     {hasActiveFilters && (
@@ -194,13 +199,14 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
                             icon="IconCircleFilled"
                             size="xxs"
                             className="text-red absolute top-[-2px] right-[-4px]"
+                            data-testid="filter-active-indicator"
                         />
                     )}
                 </div>
             </Flex>
 
             {filterDescriptionText.length > 0 && (
-                <Flex p={1}>
+                <Flex p={1} data-testid="filter-description">
                     <Text className="italic">{filterDescriptionText}</Text>
                 </Flex>
             )}
@@ -213,6 +219,7 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
             >
                 <div
                     className={`${isMobile ? "h-full" : "h-[500px]"} overflow-scroll`}
+                    data-testid="filter-dialog"
                 >
                     <Flex col className="h-full w-full" justify="between">
                         <Flex col gap={2} grow className="overflow-scroll p-4">
@@ -240,6 +247,7 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
                                             setCountrySearch(e.target.value)
                                         }
                                         placeholder="Search countries"
+                                        data-testid="country-search-input"
                                     />
 
                                     <FilterRegionOptions
@@ -287,6 +295,7 @@ const MiniAppsFilter = (props: MiniAppsFilterProps) => {
                                 width="full"
                                 onClick={() => setModalOpen(false)}
                                 className="bg-black text-white"
+                                data-testid="filter-apply"
                             >
                                 Apply
                             </Button>

--- a/app/components/dropdown.tsx
+++ b/app/components/dropdown.tsx
@@ -1,5 +1,6 @@
 import { Icon, Text } from "@fedibtc/ui"
 import { useState } from "react"
+import { dropdownTestId } from "../../e2e/helpers/test-ids"
 
 import Flex from "./flex"
 
@@ -12,6 +13,7 @@ const Dropdown = (props: DropdownProps) => {
     const { title, children } = props
 
     const [isOpen, setIsOpen] = useState<boolean>(false)
+    const testId = dropdownTestId(title)
 
     const toggleDropdown = () => {
         setIsOpen((prev) => {
@@ -21,7 +23,11 @@ const Dropdown = (props: DropdownProps) => {
 
     return (
         <Flex col gap={2}>
-            <Flex justify="between" onClick={toggleDropdown}>
+            <Flex
+                justify="between"
+                onClick={toggleDropdown}
+                data-testid={`${testId}-trigger`}
+            >
                 <Text className="font-bold">{title}</Text>
 
                 <Icon
@@ -30,7 +36,7 @@ const Dropdown = (props: DropdownProps) => {
                 />
             </Flex>
 
-            {isOpen && children}
+            {isOpen && <div data-testid={`${testId}-content`}>{children}</div>}
         </Flex>
     )
 }

--- a/app/components/item.tsx
+++ b/app/components/item.tsx
@@ -2,6 +2,7 @@ import { Button, Dialog, Icon, Text } from "@fedibtc/ui"
 import { useState } from "react"
 import QRCode from "react-qr-code"
 import { styled } from "react-tailwind-variants"
+import { miniAppTestId } from "../../e2e/helpers/test-ids"
 import { Mod } from "../lib/schemas"
 import Flex from "./flex"
 import { useViewport } from "./viewport-provider"
@@ -87,9 +88,15 @@ export default function CatalogItem({
         </Flex>
     )
 
+    const cardTestId = miniAppTestId(content.name)
+
     return (
         <>
-            <Container onClick={onShowMore} className="p-2">
+            <Container
+                onClick={onShowMore}
+                className="p-2"
+                data-testid={cardTestId}
+            >
                 <Flex grow align="center" gap={2}>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
@@ -98,6 +105,7 @@ export default function CatalogItem({
                         height={64}
                         alt={content.name}
                         className="rounded-lg self-start border border-extraLightGrey w-16 h-16 shrink-0"
+                        data-testid={`${cardTestId}-icon`}
                     />
                     <Flex col gap={1} grow>
                         <Text weight="medium">
@@ -119,6 +127,7 @@ export default function CatalogItem({
                             className="rounded-full h-4 w-4 p-4"
                             variant="secondary"
                             onClick={handleCopy}
+                            data-testid={`${cardTestId}-copy`}
                         >
                             <Icon
                                 icon="IconCopy"
@@ -133,6 +142,7 @@ export default function CatalogItem({
                                 loading={isPerformingAction}
                                 variant="secondary"
                                 onClick={handleAction}
+                                data-testid={`${cardTestId}-${isInstalled ? "added" : "add"}`}
                             >
                                 {isInstalled ? "Added" : "Add"}
                             </Button>

--- a/app/components/miniAppGroup.tsx
+++ b/app/components/miniAppGroup.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@fedibtc/ui"
+import { miniAppGroupTestId } from "../../e2e/helpers/test-ids"
 import { Mod } from "../lib/schemas"
 import Flex from "./flex"
 
@@ -20,9 +21,20 @@ const MiniAppGroup = (props: MiniAppGroupProps) => {
     })
 
     return (
-        <Flex col gap={4} p={4} width="full" className="max-w-[1200px]">
+        <Flex
+            col
+            gap={4}
+            p={4}
+            width="full"
+            className="max-w-[1200px]"
+            data-testid={miniAppGroupTestId(groupName)}
+        >
             <Flex align="center" gap={2}>
-                <Text variant="h2" weight="medium">
+                <Text
+                    variant="h2"
+                    weight="medium"
+                    data-testid={`${miniAppGroupTestId(groupName)}-heading`}
+                >
                     {groupName}
                 </Text>
             </Flex>

--- a/app/content.tsx
+++ b/app/content.tsx
@@ -54,9 +54,16 @@ export default function PageContent({
     }, [])
 
     const copyMiniAppUrl = (miniApp: Mod) => {
-        return navigator.clipboard.writeText(miniApp.url).then(() => {
-            toast.show("Copied to clipboard")
-        })
+        return navigator.clipboard
+            .writeText(miniApp.url)
+            .then(() => {
+                toast.show("Copied to clipboard")
+            })
+            .catch(() => {
+                toast.show(
+                    "Failed to copy to clipboard, please check that your browser has the correct permissions",
+                )
+            })
     }
 
     const installMiniApp = async (miniApp: Mod) => {
@@ -192,6 +199,7 @@ export default function PageContent({
                 >
                     <div
                         className={`${isMobile ? "h-full" : "h-[700px]"} overflow-scroll p-0!`}
+                        data-testid="mini-app-details-dialog"
                     >
                         <Icon
                             onClick={() => setMoreDetailsApp(undefined)}
@@ -199,6 +207,7 @@ export default function PageContent({
                             width={24}
                             height={24}
                             className="absolute top-4 right-4 cursor-pointer"
+                            data-testid="mini-app-details-dialog-close"
                         />
 
                         <MiniAppDetails

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@fedibtc/tailwind-theme": "^1.0.5",
         "@fedibtc/ui": "^1.2.5",
         "@types/sanitize-html": "^2.11.0",
-        "next": "14.2.35",
+        "next": "15.5.21",
         "react": "^18",
         "react-dom": "^18",
         "react-qr-code": "^2.0.15",
@@ -15,6 +15,7 @@
         "zod": "^3.22.4",
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/node": "^20.8.10",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -106,6 +107,56 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -118,27 +169,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@14.2.35", "", {}, "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ=="],
+    "@next/env": ["@next/env@15.5.21", "", {}, "sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.0.0", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-IB7RzmmtrPOrpAgEBR1PIQPD0yea5lggh5cq54m51jHjjljU80Ia+czfxJYMlSDl1DPvpzb8S9TalCc0VMo9Hw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@14.2.33", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@14.2.33", "", { "os": "darwin", "cpu": "x64" }, "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@14.2.33", "", { "os": "linux", "cpu": "arm64" }, "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@14.2.33", "", { "os": "linux", "cpu": "arm64" }, "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@14.2.33", "", { "os": "linux", "cpu": "x64" }, "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.21", "", { "os": "linux", "cpu": "x64" }, "sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@14.2.33", "", { "os": "linux", "cpu": "x64" }, "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.21", "", { "os": "linux", "cpu": "x64" }, "sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@14.2.33", "", { "os": "win32", "cpu": "arm64" }, "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA=="],
 
-    "@next/swc-win32-ia32-msvc": ["@next/swc-win32-ia32-msvc@14.2.33", "", { "os": "win32", "cpu": "ia32" }, "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q=="],
-
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@14.2.33", "", { "os": "win32", "cpu": "x64" }, "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.21", "", { "os": "win32", "cpu": "x64" }, "sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ=="],
 
     "@noble/ciphers": ["@noble/ciphers@0.5.3", "", {}, "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w=="],
 
@@ -155,6 +204,8 @@
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
@@ -222,9 +273,7 @@
 
     "@scure/bip39": ["@scure/bip39@1.2.1", "", { "dependencies": { "@noble/hashes": "~1.3.0", "@scure/base": "~1.1.0" } }, "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg=="],
 
-    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
-
-    "@swc/helpers": ["@swc/helpers@0.5.5", "", { "dependencies": { "@swc/counter": "^0.1.3", "tslib": "^2.4.0" } }, "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A=="],
+    "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tabler/icons": ["@tabler/icons@2.47.0", "", {}, "sha512-4w5evLh+7FUUiA1GucvGj2ReX2TvOjEr4ejXdwL/bsjoSkof6r1gQmzqI+VHrE2CpJpB3al7bCTulOkFa/RcyA=="],
 
@@ -370,8 +419,6 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
-
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -423,6 +470,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
@@ -536,7 +585,7 @@
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -726,7 +775,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@14.2.35", "", { "dependencies": { "@next/env": "14.2.35", "@swc/helpers": "0.5.5", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "graceful-fs": "^4.2.11", "postcss": "8.4.31", "styled-jsx": "5.1.1" }, "optionalDependencies": { "@next/swc-darwin-arm64": "14.2.33", "@next/swc-darwin-x64": "14.2.33", "@next/swc-linux-arm64-gnu": "14.2.33", "@next/swc-linux-arm64-musl": "14.2.33", "@next/swc-linux-x64-gnu": "14.2.33", "@next/swc-linux-x64-musl": "14.2.33", "@next/swc-win32-arm64-msvc": "14.2.33", "@next/swc-win32-ia32-msvc": "14.2.33", "@next/swc-win32-x64-msvc": "14.2.33" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "react": "^18.2.0", "react-dom": "^18.2.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig=="],
+    "next": ["next@15.5.21", "", { "dependencies": { "@next/env": "15.5.21", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.21", "@next/swc-darwin-x64": "15.5.21", "@next/swc-linux-arm64-gnu": "15.5.21", "@next/swc-linux-arm64-musl": "15.5.21", "@next/swc-linux-x64-gnu": "15.5.21", "@next/swc-linux-x64-musl": "15.5.21", "@next/swc-win32-arm64-msvc": "15.5.21", "@next/swc-win32-x64-msvc": "15.5.21", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
@@ -781,6 +830,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -866,6 +919,8 @@
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -886,8 +941,6 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
-    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
-
     "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
 
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
@@ -904,7 +957,7 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
-    "styled-jsx": ["styled-jsx@5.1.1", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0" } }, "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw=="],
+    "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
@@ -1047,6 +1100,8 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/e2e/browser-mode/catalog-display.spec.ts
+++ b/e2e/browser-mode/catalog-display.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "../fixtures/base"
+import { miniAppGroupTestId } from "../helpers/test-ids"
+
+test.describe("Browser Mode - Page Load & Layout", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+    })
+
+    test("page title is visible", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+    })
+
+    test("New section shows new apps", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        const newSection = catalogPage.getMiniAppGroup("New")
+        await expect(newSection).toBeVisible()
+        await expect(newSection.locator("[data-testid$='-icon']")).toHaveCount(
+            6,
+        )
+    })
+
+    test("all 6 category groups render in correct order", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+
+        const expectedGroups = [
+            "New",
+            "Spend & Earn Bitcoin",
+            "Misc",
+            "Cash In & Cash Out",
+            "Productivity",
+            "Communications",
+            "AI & Chatbots",
+            "Games",
+        ]
+
+        const headings = page.locator("[data-testid$='-heading']")
+        const headingTexts: string[] = []
+        const count = await headings.count()
+        for (let i = 0; i < count; i++) {
+            headingTexts.push((await headings.nth(i).textContent()) || "")
+        }
+
+        expect(headingTexts.map((t) => t.trim())).toEqual(expectedGroups)
+    })
+
+    test("mini app cards show icon, name, description, and copy button", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+
+        const firstCard = page
+            .getByTestId(miniAppGroupTestId("New"))
+            .locator("[data-testid^='mini-app-']")
+            .first()
+        await expect(firstCard.locator("[data-testid$='-icon']")).toBeVisible()
+        await expect(firstCard.locator("[data-testid$='-copy']")).toBeVisible()
+    })
+
+    test("mini apps sorted alphabetically within groups", async ({
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+
+        const spendGroup = catalogPage.getMiniAppGroup("Spend & Earn Bitcoin")
+
+        const names: string[] = []
+        const images = spendGroup.locator("[data-testid$='-icon']")
+        const count = await images.count()
+        for (let i = 0; i < count; i++) {
+            const alt = await images.nth(i).getAttribute("alt")
+            if (alt) names.push(alt)
+        }
+
+        const sorted = [...names].sort((a, b) => a.localeCompare(b))
+        expect(names).toEqual(sorted)
+    })
+
+    test("no Add buttons visible in browser mode", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        const addButtons = page.getByRole("button", {
+            name: "Add",
+            exact: true,
+        })
+        await expect(addButtons).toHaveCount(0)
+    })
+
+    test("copy button copies URL and shows toast", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+
+        const firstCopyButton = page.locator("[data-testid$='-copy']").first()
+        await firstCopyButton.click()
+
+        await expect(
+            page.getByText("Copied to clipboard", { exact: true }),
+        ).toBeVisible()
+    })
+})

--- a/e2e/browser-mode/filter-modal.spec.ts
+++ b/e2e/browser-mode/filter-modal.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from "../fixtures/base"
+import { filterOptionTestId } from "../helpers/test-ids"
+
+test.describe("Browser Mode - Filter Modal", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+    })
+
+    test("opens when clicking filter icon", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await expect(page.getByTestId("filter-dialog")).toBeVisible()
+    })
+
+    test("closes on Apply click", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.closeFilterModal()
+        await expect(page.getByRole("dialog")).not.toBeVisible()
+    })
+
+    test("category dropdown shows 6 categories", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+
+        const categories = [
+            "Spend and Earn Bitcoin",
+            "Cash in and cash out",
+            "Productivity",
+            "Communication",
+            "AI & Chatbots",
+            "Misc",
+        ]
+
+        for (const category of categories) {
+            await expect(
+                page.getByTestId(filterOptionTestId("category", category)),
+            ).toBeVisible()
+        }
+    })
+
+    test("filtering by category shows correct results", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+
+        await page
+            .getByTestId(filterOptionTestId("category", "AI & Chatbots"))
+            .click()
+        await catalogPage.closeFilterModal()
+
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "Category: AI & Chatbots",
+        )
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+    })
+
+    test("region dropdown shows region buttons with Global first", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Region & Country")
+
+        await expect(
+            page.getByTestId(filterOptionTestId("region", "Global")),
+        ).toBeVisible()
+        await expect(
+            page.getByTestId(filterOptionTestId("region", "Africa")),
+        ).toBeVisible()
+        await expect(
+            page.getByTestId(filterOptionTestId("region", "Europe")),
+        ).toBeVisible()
+    })
+
+    test("filtering by region shows filter description", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Region & Country")
+
+        await page.getByTestId(filterOptionTestId("region", "Global")).click()
+        await catalogPage.closeFilterModal()
+
+        await expect(catalogPage.getFilterDescription()).toContainText(
+            "Region: Global",
+        )
+    })
+
+    test("country list shows first 6 and View more", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Region & Country")
+
+        await expect(page.getByTestId("country-view-more")).toBeVisible()
+    })
+
+    test("country search works", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Region & Country")
+
+        await page.getByTestId("country-search-input").fill("United States")
+
+        await expect(
+            page.getByTestId(filterOptionTestId("country", "United States")),
+        ).toBeVisible()
+    })
+
+    test("Reset clears all filters", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+
+        await page
+            .getByTestId(filterOptionTestId("category", "AI & Chatbots"))
+            .click()
+
+        await page.getByTestId("filter-reset").click()
+
+        await catalogPage.closeFilterModal()
+
+        await expect(catalogPage.getFilterDescription()).not.toBeVisible()
+    })
+
+    test("search and filter combination works", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+        await page
+            .getByTestId(filterOptionTestId("category", "AI & Chatbots"))
+            .click()
+        await catalogPage.closeFilterModal()
+
+        await catalogPage.getSearchInput().fill("AI")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+    })
+
+    test("filter indicator dot appears when filters active", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+
+        await expect(catalogPage.getFilterIndicator()).not.toBeVisible()
+
+        await catalogPage.openFilterModal()
+        await catalogPage.openDropdown("Category")
+        await page
+            .getByTestId(filterOptionTestId("category", "AI & Chatbots"))
+            .click()
+        await catalogPage.closeFilterModal()
+
+        await expect(catalogPage.getFilterIndicator()).toBeVisible()
+    })
+})

--- a/e2e/browser-mode/mini-app-details.spec.ts
+++ b/e2e/browser-mode/mini-app-details.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from "../fixtures/base"
+import { miniAppTestId } from "../helpers/test-ids"
+
+test.describe("Browser Mode - Details Modal", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+    })
+
+    test("opens on card click with name, description, icon, and URL", async ({
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog).toBeVisible()
+        await expect(dialog.getByText("Boltz", { exact: true })).toBeVisible()
+        await expect(
+            dialog.getByText("Swap between different Bitcoin layers"),
+        ).toBeVisible()
+        await expect(dialog.locator("img[alt='Boltz']")).toBeVisible()
+        await expect(dialog.locator("img[width='96']")).toBeVisible()
+        await expect(
+            dialog.getByText("https://boltz.exchange/", { exact: true }),
+        ).toBeVisible()
+    })
+
+    test("QR code button shows QR view", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await dialog
+            .getByTestId(`${miniAppTestId("Boltz")}-details-qr-open`)
+            .click()
+
+        await expect(
+            dialog.getByTestId(`${miniAppTestId("Boltz")}-details-qr-view`),
+        ).toBeVisible()
+    })
+
+    test("close QR returns to details", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await dialog
+            .getByTestId(`${miniAppTestId("Boltz")}-details-qr-open`)
+            .click()
+
+        await dialog
+            .getByTestId(`${miniAppTestId("Boltz")}-details-qr-close`)
+            .click()
+
+        await expect(
+            dialog.getByText("https://boltz.exchange/", { exact: true }),
+        ).toBeVisible()
+    })
+
+    test("category badge displayed", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog.getByText("Category")).toBeVisible()
+        await expect(dialog.getByText("Cash in and cash out")).toBeVisible()
+    })
+
+    test("keyword badges displayed", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Timechain Calendar")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog.getByText("Keywords")).toBeVisible()
+        await expect(dialog.getByText("bitcoin explorer")).toBeVisible()
+    })
+
+    test("privacy policy link displayed when the mini app has one", async ({
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog.getByText("Privacy policy")).toBeVisible()
+        const link = dialog.getByTestId(
+            `${miniAppTestId("Boltz")}-details-privacy-policy`,
+        )
+        await expect(link).toHaveAttribute(
+            "href",
+            "https://boltz.exchange/privacy",
+        )
+        await expect(link).toHaveAttribute("target", "_blank")
+    })
+
+    test("privacy policy falls back to <origin>/privacy-policy when the mini app declares none", async ({
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("bitsimp")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog.getByText("Privacy policy")).toBeVisible()
+        await expect(
+            dialog.getByTestId(
+                `${miniAppTestId("bitsimp")}-details-privacy-policy`,
+            ),
+        ).toHaveAttribute("href", "https://bitsimp.com/privacy-policy")
+    })
+
+    test("View more/View less toggles extended description", async ({
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("bitsimp")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog.getByText("View more")).toBeVisible()
+
+        await dialog.getByText("View more").click()
+        await expect(dialog.getByText("View less")).toBeVisible()
+
+        await dialog.getByText("View less").click()
+        await expect(dialog.getByText("View more")).toBeVisible()
+    })
+
+    test("X button closes the dialog", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog).toBeVisible()
+
+        await page.getByTestId("mini-app-details-dialog-close").click()
+        await expect(dialog).not.toBeVisible()
+    })
+
+    test("copy URL in details shows toast", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await dialog
+            .getByTestId(`${miniAppTestId("Boltz")}-details-copy`)
+            .click()
+
+        await expect(
+            page.getByText("Copied to clipboard", { exact: true }),
+        ).toBeVisible()
+    })
+
+    test("no Add button in details modal in browser mode", async ({
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(
+            dialog.getByRole("button", { name: "Add", exact: true }),
+        ).not.toBeVisible()
+    })
+})

--- a/e2e/browser-mode/search.spec.ts
+++ b/e2e/browser-mode/search.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "../fixtures/base"
+
+test.describe("Browser Mode - Search", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+    })
+
+    test("filter by name shows matching app", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("Boltz")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(page.locator("img[alt='Boltz']").first()).toBeVisible()
+    })
+
+    test("filter by description keyword", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("chatbot")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(
+            page.locator("img[alt='AI Assistant']").first(),
+        ).toBeVisible()
+    })
+
+    test("filter by app keywords", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("bitcoin explorer")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+        await expect(
+            page.locator("img[alt='Timechain Calendar']").first(),
+        ).toBeVisible()
+    })
+
+    test("shows filtered results count header", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("Boltz")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+    })
+
+    test("no results found for non-matching search", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("zzzznonexistent")
+        await expect(page.getByText("No results found")).toBeVisible()
+    })
+
+    test("results sorted alphabetically", async ({ page, catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("bitcoin")
+        const heading = catalogPage.getFilteredResultsHeading()
+        await expect(heading).toBeVisible()
+
+        const headingText = await heading.textContent()
+        const filteredCount = parseInt(headingText?.match(/\d+/)?.[0] || "0")
+        expect(filteredCount).toBeGreaterThan(1)
+
+        const names: string[] = []
+        const images = page.locator("img[alt]")
+        for (let i = 0; i < filteredCount; i++) {
+            const alt = await images.nth(i).getAttribute("alt")
+            if (alt) names.push(alt)
+        }
+
+        const sorted = [...names].sort((a, b) => a.localeCompare(b))
+        expect(names).toEqual(sorted)
+    })
+
+    test("clearing search restores full catalog", async ({ catalogPage }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("Boltz")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+
+        await catalogPage.getSearchInput().clear()
+        await expect(catalogPage.getMiniAppGroup("New")).toBeVisible()
+        await expect(
+            catalogPage.getMiniAppGroup("Spend & Earn Bitcoin"),
+        ).toBeVisible()
+    })
+
+    test.fixme("regex special characters do not crash the page", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("[invalid(regex")
+        await expect(page.getByText("No results found")).toBeVisible()
+    })
+})

--- a/e2e/fedi-mode/catalog-display.spec.ts
+++ b/e2e/fedi-mode/catalog-display.spec.ts
@@ -1,0 +1,85 @@
+import { expect, injectFediMock, test } from "../fixtures/base"
+
+test.describe("Fedi Mode - Page Load with Fedi API", () => {
+    test("page loads with fedi mock injected", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+    })
+
+    test("Add buttons visible on mini app cards", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const addButtons = page.getByRole("button", {
+            name: "Add",
+            exact: true,
+        })
+        expect(await addButtons.count()).toBeGreaterThan(0)
+    })
+
+    test("Added (disabled) for pre-installed apps", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page, {
+            installedApps: [{ url: "https://boltz.exchange/" }],
+        })
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const boltzCard = catalogPage.getMiniAppCard("Boltz")
+        const addedButton = boltzCard.getByRole("button", {
+            name: "Added",
+            exact: true,
+        })
+        await expect(addedButton).toBeVisible()
+        await expect(addedButton).toBeDisabled()
+    })
+
+    test("all 6 category groups render with fedi mode", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const expectedGroups = [
+            "Spend & Earn Bitcoin",
+            "Misc",
+            "Cash In & Cash Out",
+            "Productivity",
+            "Communications",
+            "AI & Chatbots",
+        ]
+
+        for (const group of expectedGroups) {
+            await expect(
+                page.locator(".text-h2").filter({ hasText: group }),
+            ).toBeVisible()
+        }
+    })
+
+    test("copy button still works in fedi mode", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const firstCopyButton = page.locator("[data-testid$='-copy']").first()
+        await firstCopyButton.click()
+        await expect(
+            page.getByText("Copied to clipboard", { exact: true }),
+        ).toBeVisible()
+    })
+})

--- a/e2e/fedi-mode/install-flow.spec.ts
+++ b/e2e/fedi-mode/install-flow.spec.ts
@@ -1,0 +1,103 @@
+import { expect, injectFediMock, test } from "../fixtures/base"
+
+test.describe("Fedi Mode - Install Flow", () => {
+    test("click Add on card changes to Added", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const boltzCard = catalogPage.getMiniAppCard("Boltz")
+        const addButton = boltzCard.getByRole("button", {
+            name: "Add",
+            exact: true,
+        })
+        await expect(addButton).toBeVisible()
+        await addButton.click()
+
+        await expect(
+            boltzCard.getByRole("button", { name: "Added", exact: true }),
+        ).toBeVisible()
+        await expect(
+            boltzCard.getByRole("button", { name: "Added", exact: true }),
+        ).toBeDisabled()
+    })
+
+    test("after installing, app shows Added in details modal", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const boltzCard = catalogPage.getMiniAppCard("Boltz")
+        await boltzCard
+            .getByRole("button", { name: "Add", exact: true })
+            .click()
+        await expect(
+            boltzCard.getByRole("button", { name: "Added", exact: true }),
+        ).toBeVisible()
+
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(
+            dialog.getByRole("button", { name: "Added", exact: true }),
+        ).toBeVisible()
+        await expect(
+            dialog.getByRole("button", { name: "Added", exact: true }),
+        ).toBeDisabled()
+    })
+
+    test("installing one app does not affect other apps", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const boltzCard = catalogPage.getMiniAppCard("Boltz")
+        await boltzCard
+            .getByRole("button", { name: "Add", exact: true })
+            .click()
+        await expect(
+            boltzCard.getByRole("button", { name: "Added", exact: true }),
+        ).toBeVisible()
+
+        const aiCard = catalogPage.getMiniAppCard("AI Assistant")
+        await expect(
+            aiCard.getByRole("button", { name: "Add", exact: true }),
+        ).toBeVisible()
+    })
+
+    test("multiple apps can be installed in sequence", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        const boltzCard = catalogPage.getMiniAppCard("Boltz")
+        await boltzCard
+            .getByRole("button", { name: "Add", exact: true })
+            .click()
+        await expect(
+            boltzCard.getByRole("button", { name: "Added", exact: true }),
+        ).toBeVisible()
+
+        const aiCard = catalogPage.getMiniAppCard("AI Assistant")
+        await aiCard.getByRole("button", { name: "Add", exact: true }).click()
+        await expect(
+            aiCard.getByRole("button", { name: "Added", exact: true }),
+        ).toBeVisible()
+
+        await expect(
+            boltzCard.getByRole("button", { name: "Added", exact: true }),
+        ).toBeVisible()
+    })
+})

--- a/e2e/fedi-mode/mini-app-details.spec.ts
+++ b/e2e/fedi-mode/mini-app-details.spec.ts
@@ -1,0 +1,88 @@
+import { expect, injectFediMock, test } from "../fixtures/base"
+import { miniAppTestId } from "../helpers/test-ids"
+
+test.describe("Fedi Mode - Details Modal", () => {
+    test("Add button visible in details modal", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(
+            dialog.getByRole("button", { name: "Add", exact: true }),
+        ).toBeVisible()
+    })
+
+    test("Added (disabled) in details for pre-installed apps", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page, {
+            installedApps: [{ url: "https://boltz.exchange/" }],
+        })
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        const addedButton = dialog.getByRole("button", {
+            name: "Added",
+            exact: true,
+        })
+        await expect(addedButton).toBeVisible()
+        await expect(addedButton).toBeDisabled()
+    })
+
+    test("QR code and copy URL still work alongside Add button", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Boltz")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(
+            dialog.getByRole("button", { name: "Add", exact: true }),
+        ).toBeVisible()
+
+        await dialog
+            .getByTestId(`${miniAppTestId("Boltz")}-details-qr-open`)
+            .click()
+        await expect(
+            dialog.getByTestId(`${miniAppTestId("Boltz")}-details-qr-view`),
+        ).toBeVisible()
+        await dialog
+            .getByTestId(`${miniAppTestId("Boltz")}-details-qr-close`)
+            .click()
+
+        await dialog
+            .getByTestId(`${miniAppTestId("Boltz")}-details-copy`)
+            .click()
+        await expect(
+            page.getByText("Copied to clipboard", { exact: true }),
+        ).toBeVisible()
+    })
+
+    test("all detail fields display correctly with fedi mode", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.clickMiniAppCard("Timechain Calendar")
+
+        const dialog = catalogPage.getDetailsDialog()
+        await expect(dialog.getByText("Category")).toBeVisible()
+        await expect(dialog.getByText("Misc")).toBeVisible()
+        await expect(dialog.getByText("Keywords")).toBeVisible()
+        await expect(dialog.getByText("bitcoin explorer")).toBeVisible()
+        await expect(dialog.getByText("View more")).toBeVisible()
+    })
+})

--- a/e2e/fedi-mode/search.spec.ts
+++ b/e2e/fedi-mode/search.spec.ts
@@ -1,0 +1,59 @@
+import { expect, injectFediMock, test } from "../fixtures/base"
+
+test.describe("Fedi Mode - Search", () => {
+    test.beforeEach(async ({ page }) => {
+        await injectFediMock(page)
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+    })
+
+    test("search results show both Add and copy buttons", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("Boltz")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+
+        await expect(
+            page.locator("[data-testid$='-copy']").first(),
+        ).toBeVisible()
+        await expect(
+            page.getByRole("button", { name: "Add", exact: true }).first(),
+        ).toBeVisible()
+    })
+
+    test("filtering works correctly with Add buttons persisting", async ({
+        page,
+        catalogPage,
+    }) => {
+        await catalogPage.waitForCatalogReady()
+        await catalogPage.getSearchInput().fill("bitcoin")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+
+        const addButtons = page.getByRole("button", {
+            name: "Add",
+            exact: true,
+        })
+        expect(await addButtons.count()).toBeGreaterThan(0)
+    })
+
+    test("Added state persists in filtered results for pre-installed apps", async ({
+        page,
+        catalogPage,
+    }) => {
+        await injectFediMock(page, {
+            installedApps: [{ url: "https://boltz.exchange/" }],
+        })
+        await page.goto("/", { waitUntil: "domcontentloaded" })
+        await catalogPage.waitForCatalogReady()
+
+        await catalogPage.getSearchInput().fill("Boltz")
+        await expect(catalogPage.getFilteredResultsHeading()).toBeVisible()
+
+        const addedButton = page
+            .getByRole("button", { name: "Added", exact: true })
+            .first()
+        await expect(addedButton).toBeVisible()
+        await expect(addedButton).toBeDisabled()
+    })
+})

--- a/e2e/fixtures/base.ts
+++ b/e2e/fixtures/base.ts
@@ -1,0 +1,117 @@
+import { test as base, expect, Locator, Page } from "@playwright/test"
+import { injectFediMock } from "../helpers/fedi-mock"
+import {
+    dropdownTestId,
+    miniAppGroupTestId,
+    miniAppTestId,
+} from "../helpers/test-ids"
+
+type CatalogPage = {
+    waitForCatalogReady: () => Promise<void>
+    getSearchInput: () => Locator
+    getFilterTrigger: () => Locator
+    getFilterIndicator: () => Locator
+    getFilterDescription: () => Locator
+    getFilteredResultsHeading: () => Locator
+    getMiniAppCard: (name: string) => Locator
+    getMiniAppGroup: (name: string) => Locator
+    getDetailsDialog: () => Locator
+    openFilterModal: () => Promise<void>
+    closeFilterModal: () => Promise<void>
+    openDropdown: (title: string) => Promise<void>
+    clickMiniAppCard: (name: string) => Promise<void>
+}
+
+type FediCatalogPage = CatalogPage & {
+    getAddButton: (name: string) => Locator
+    getAddedButton: (name: string) => Locator
+}
+
+export const test = base.extend<{
+    catalogPage: CatalogPage
+    fediCatalogPage: FediCatalogPage
+}>({
+    catalogPage: async ({ page }, applyCatalogPage) => {
+        await page
+            .context()
+            .grantPermissions(["clipboard-read", "clipboard-write"])
+
+        const helpers = createCatalogHelpers(page)
+        await applyCatalogPage(helpers)
+    },
+
+    fediCatalogPage: async ({ page }, applyFediCatalogPage) => {
+        await page
+            .context()
+            .grantPermissions(["clipboard-read", "clipboard-write"])
+
+        const helpers = createCatalogHelpers(page)
+
+        const fediHelpers: FediCatalogPage = {
+            ...helpers,
+            getAddButton: (name: string) => {
+                const card = helpers.getMiniAppCard(name)
+                return card.getByRole("button", { name: "Add", exact: true })
+            },
+            getAddedButton: (name: string) => {
+                const card = helpers.getMiniAppCard(name)
+                return card.getByRole("button", { name: "Added", exact: true })
+            },
+        }
+
+        await applyFediCatalogPage(fediHelpers)
+    },
+})
+
+function createCatalogHelpers(page: Page): CatalogPage {
+    return {
+        waitForCatalogReady: async () => {
+            await expect(page.getByText("Fedi Mini Apps Catalog")).toBeVisible({
+                timeout: 15_000,
+            })
+        },
+        getSearchInput: () => {
+            return page.getByTestId("catalog-search-input")
+        },
+        getFilterTrigger: () => {
+            return page.getByTestId("filter-trigger")
+        },
+        getFilterIndicator: () => {
+            return page.getByTestId("filter-active-indicator")
+        },
+        getFilterDescription: () => {
+            return page.getByTestId("filter-description")
+        },
+        getFilteredResultsHeading: () => {
+            return page.getByTestId("filtered-results-heading")
+        },
+        getMiniAppCard: (name: string) => {
+            return page.getByTestId(miniAppTestId(name)).first()
+        },
+        getMiniAppGroup: (name: string) => {
+            return page.getByTestId(miniAppGroupTestId(name))
+        },
+        getDetailsDialog: () => {
+            return page.getByTestId("mini-app-details-dialog")
+        },
+        openFilterModal: async () => {
+            await page.getByTestId("filter-trigger").click()
+            await expect(page.getByTestId("filter-dialog")).toBeVisible()
+        },
+        closeFilterModal: async () => {
+            await page.getByTestId("filter-apply").click()
+            await expect(page.getByTestId("filter-dialog")).not.toBeVisible()
+        },
+        openDropdown: async (title: string) => {
+            await page.getByTestId(`${dropdownTestId(title)}-trigger`).click()
+            await expect(
+                page.getByTestId(`${dropdownTestId(title)}-content`),
+            ).toBeVisible()
+        },
+        clickMiniAppCard: async (name: string) => {
+            await page.getByTestId(miniAppTestId(name)).first().click()
+        },
+    }
+}
+
+export { expect, injectFediMock }

--- a/e2e/helpers/fedi-mock.ts
+++ b/e2e/helpers/fedi-mock.ts
@@ -1,0 +1,26 @@
+import { Page } from "@playwright/test"
+
+type FediInternalMock = {
+    version: number
+    getInstalledMiniApps: () => Promise<Array<{ url: string }>>
+    installMiniApp: (miniApp: { url: string }) => Promise<void>
+}
+
+export async function injectFediMock(
+    page: Page,
+    options?: {
+        installedApps?: Array<{ url: string }>
+    },
+) {
+    await page.addInitScript((apps) => {
+        const installed = [...apps]
+        ;(window as Window & { fediInternal?: FediInternalMock }).fediInternal =
+            {
+                version: 2,
+                getInstalledMiniApps: async () => [...installed],
+                installMiniApp: async (miniApp: { url: string }) => {
+                    installed.push({ url: miniApp.url })
+                },
+            }
+    }, options?.installedApps ?? [])
+}

--- a/e2e/helpers/test-ids.ts
+++ b/e2e/helpers/test-ids.ts
@@ -1,0 +1,26 @@
+const sanitizeForTestId = (value: string) => {
+    return value
+        .toLowerCase()
+        .replace(/&/g, "and")
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+}
+
+export const miniAppTestId = (name: string) => {
+    return `mini-app-${sanitizeForTestId(name)}`
+}
+
+export const miniAppGroupTestId = (groupName: string) => {
+    return `catalog-group-${sanitizeForTestId(groupName)}`
+}
+
+export const dropdownTestId = (title: string) => {
+    return `dropdown-${sanitizeForTestId(title)}`
+}
+
+export const filterOptionTestId = (
+    kind: "category" | "country" | "region",
+    label: string,
+) => {
+    return `${kind}-option-${sanitizeForTestId(label)}`
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "format:check": "prettier --check \"app/**/*.{ts,tsx,css}\"",
     "type-check": "tsc --noEmit",
     "lint:all": "bun run lint:check && bun run format:check && bun run type-check",
+    "test:e2e": "bunx playwright test",
+    "test:e2e:ui": "bunx playwright test --ui",
+    "test:e2e:headed": "bunx playwright test --headed",
     "postinstall": "patch-package"
   },
   "trustedDependencies": [
@@ -21,7 +24,7 @@
     "@fedibtc/tailwind-theme": "^1.0.5",
     "@fedibtc/ui": "^1.2.5",
     "@types/sanitize-html": "^2.11.0",
-    "next": "14.2.35",
+    "next": "15.5.21",
     "react": "^18",
     "react-dom": "^18",
     "react-qr-code": "^2.0.15",
@@ -29,6 +32,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^20.8.10",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -37,10 +41,10 @@
     "eslint-config-next": "16.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
-    "prettier": "^3.6.2",
-    "prettier-plugin-organize-imports": "^4.3.0",
     "patch-package": "^8.0.1",
     "postcss": "^8",
+    "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.3.0",
     "tailwindcss": "^3",
     "typescript": "^5.2.2"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const isCI = !!process.env.CI
+const deployedUrl = process.env.E2E_BASE_URL
+
+export default defineConfig({
+    testDir: "./e2e",
+    fullyParallel: true,
+    forbidOnly: isCI,
+    retries: isCI ? 1 : 0,
+    workers: isCI ? 1 : undefined,
+    reporter: "html",
+    use: {
+        baseURL: deployedUrl ?? "http://localhost:3023",
+        trace: "on-first-retry",
+        navigationTimeout: 15_000,
+    },
+    projects: [
+        {
+            name: "chromium",
+            use: { ...devices["Desktop Chrome"] },
+        },
+    ],
+    webServer: deployedUrl
+        ? undefined
+        : {
+              command: "bun run build && bunx next start -p 3023",
+              url: "http://localhost:3023",
+              reuseExistingServer: !isCI,
+              timeout: 120_000,
+          },
+})

--- a/scripts/check-ui-code.sh
+++ b/scripts/check-ui-code.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+MODE=${MODE:-check}
+
+pushd "$REPO_ROOT" >/dev/null
+
+echo "Installing dependencies..."
+bun install
+
+if [[ -n "${CI:-}" ]]; then
+    echo "Running UI code checks in CI"
+
+    echo "Running lint..."
+    bun run lint
+
+    echo "Running format..."
+    bun run format
+
+    popd >/dev/null
+    CHANGES=$(git status --porcelain)
+    if [[ -z "$CHANGES" ]]; then
+        echo "All UI code is correctly linted and formatted"
+    else
+        echo "The following files must be linted/formatted. Run 'MODE=write ./scripts/check-ui-code.sh' to fix the errors"
+        echo "$CHANGES"
+        exit 1
+    fi
+
+    pushd "$REPO_ROOT" >/dev/null
+    echo "Running type check..."
+    bun run type-check
+
+    echo "All checks passed!"
+else
+    if [[ "$MODE" == "write" ]]; then
+        echo "Running UI code checks in fix mode"
+
+        echo "Fixing lint errors..."
+        bun run lint
+
+        echo "Fixing format errors..."
+        bun run format
+
+        echo "Running type check..."
+        bun run type-check
+
+        echo "All fixes applied and checks passed!"
+    else
+        echo "Running UI code checks in check mode"
+
+        echo "Checking lint..."
+        bun run lint:check
+
+        echo "Checking format..."
+        bun run format:check
+
+        echo "Running type check..."
+        bun run type-check
+
+        echo "All checks passed!"
+    fi
+fi
+
+popd >/dev/null

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,34 +7,34 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
-"@babel/code-frame@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.28.6.tgz#72499312ec58b1e2245ba4a4f550c132be4982f7"
-  integrity sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==
+"@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/helper-validator-identifier" "^7.29.7"
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.6.tgz#103f466803fa0f059e82ccac271475470570d74c"
-  integrity sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
 
 "@babel/core@^7.24.4":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.28.6.tgz#531bf883a1126e53501ba46eb3bb414047af507f"
-  integrity sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
   dependencies:
-    "@babel/code-frame" "^7.28.6"
-    "@babel/generator" "^7.28.6"
-    "@babel/helper-compilation-targets" "^7.28.6"
-    "@babel/helper-module-transforms" "^7.28.6"
-    "@babel/helpers" "^7.28.6"
-    "@babel/parser" "^7.28.6"
-    "@babel/template" "^7.28.6"
-    "@babel/traverse" "^7.28.6"
-    "@babel/types" "^7.28.6"
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
     "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
@@ -42,100 +42,117 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.6.tgz#48dcc65d98fcc8626a48f72b62e263d25fc3c3f1"
-  integrity sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==
+"@babel/generator@^7.29.7", "@babel/generator@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.8.tgz#4b0b887885422643339e09022148a4c4ebaa4979"
+  integrity sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==
   dependencies:
-    "@babel/parser" "^7.28.6"
-    "@babel/types" "^7.28.6"
+    "@babel/parser" "^7.29.8"
+    "@babel/types" "^7.29.8"
     "@jridgewell/gen-mapping" "^0.3.12"
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
-"@babel/helper-compilation-targets@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz#32c4a3f41f12ed1532179b108a4d746e105c2b25"
-  integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
   dependencies:
-    "@babel/compat-data" "^7.28.6"
-    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-globals@^7.28.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
-  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
 
-"@babel/helper-module-imports@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
-  integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
   dependencies:
-    "@babel/traverse" "^7.28.6"
-    "@babel/types" "^7.28.6"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
-"@babel/helper-module-transforms@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz#9312d9d9e56edc35aeb6e95c25d4106b50b9eb1e"
-  integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
   dependencies:
-    "@babel/helper-module-imports" "^7.28.6"
-    "@babel/helper-validator-identifier" "^7.28.5"
-    "@babel/traverse" "^7.28.6"
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
-"@babel/helper-validator-option@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
-  integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
-"@babel/helpers@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.6.tgz#fca903a313ae675617936e8998b814c415cbf5d7"
-  integrity sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
   dependencies:
-    "@babel/template" "^7.28.6"
-    "@babel/types" "^7.28.6"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
-"@babel/parser@^7.24.4", "@babel/parser@^7.28.6":
+"@babel/parser@^7.24.4":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.6.tgz#f01a8885b7fa1e56dd8a155130226cd698ef13fd"
   integrity sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==
   dependencies:
     "@babel/types" "^7.28.6"
 
-"@babel/template@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
-  integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
+"@babel/parser@^7.29.7", "@babel/parser@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
   dependencies:
-    "@babel/code-frame" "^7.28.6"
-    "@babel/parser" "^7.28.6"
-    "@babel/types" "^7.28.6"
+    "@babel/types" "^7.29.8"
 
-"@babel/traverse@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.6.tgz#871ddc79a80599a5030c53b1cc48cbe3a5583c2e"
-  integrity sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
   dependencies:
-    "@babel/code-frame" "^7.28.6"
-    "@babel/generator" "^7.28.6"
-    "@babel/helper-globals" "^7.28.0"
-    "@babel/parser" "^7.28.6"
-    "@babel/template" "^7.28.6"
-    "@babel/types" "^7.28.6"
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/traverse@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.8.tgz#4111014cdc71a0f95d9471907590baa0b8a6b28a"
+  integrity sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.8"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.8"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.8"
     debug "^4.3.1"
 
 "@babel/types@^7.28.6":
@@ -146,6 +163,14 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@babel/types@^7.29.7", "@babel/types@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+
 "@emnapi/core@^1.4.3":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.8.1.tgz#fd9efe721a616288345ffee17a1f26ac5dd01349"
@@ -154,7 +179,7 @@
     "@emnapi/wasi-threads" "1.1.0"
     tslib "^2.4.0"
 
-"@emnapi/runtime@^1.4.3":
+"@emnapi/runtime@^1.4.3", "@emnapi/runtime@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.8.1.tgz#550fa7e3c0d49c5fb175a116e8cd70614f9a22a5"
   integrity sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==
@@ -281,6 +306,153 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@img/colour@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.0.0.tgz#d2fabb223455a793bf3bf9c70de3d28526aa8311"
+  integrity sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==
+
+"@img/sharp-darwin-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz#6e0732dcade126b6670af7aa17060b926835ea86"
+  integrity sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-arm64" "1.2.4"
+
+"@img/sharp-darwin-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz#19bc1dd6eba6d5a96283498b9c9f401180ee9c7b"
+  integrity sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.2.4"
+
+"@img/sharp-libvips-darwin-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz#2894c0cb87d42276c3889942e8e2db517a492c43"
+  integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
+
+"@img/sharp-libvips-darwin-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz#e63681f4539a94af9cd17246ed8881734386f8cc"
+  integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
+
+"@img/sharp-libvips-linux-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz#b1b288b36864b3bce545ad91fa6dadcf1a4ad318"
+  integrity sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==
+
+"@img/sharp-libvips-linux-arm@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz#b9260dd1ebe6f9e3bdbcbdcac9d2ac125f35852d"
+  integrity sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==
+
+"@img/sharp-libvips-linux-ppc64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz#4b83ecf2a829057222b38848c7b022e7b4d07aa7"
+  integrity sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==
+
+"@img/sharp-libvips-linux-riscv64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz#880b4678009e5a2080af192332b00b0aaf8a48de"
+  integrity sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==
+
+"@img/sharp-libvips-linux-s390x@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz#74f343c8e10fad821b38f75ced30488939dc59ec"
+  integrity sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==
+
+"@img/sharp-libvips-linux-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz#df4183e8bd8410f7d61b66859a35edeab0a531ce"
+  integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
+
+"@img/sharp-libvips-linuxmusl-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz#c8d6b48211df67137541007ee8d1b7b1f8ca8e06"
+  integrity sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==
+
+"@img/sharp-libvips-linuxmusl-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz#be11c75bee5b080cbee31a153a8779448f919f75"
+  integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
+
+"@img/sharp-linux-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz#7aa7764ef9c001f15e610546d42fce56911790cc"
+  integrity sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm64" "1.2.4"
+
+"@img/sharp-linux-arm@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz#5fb0c3695dd12522d39c3ff7a6bc816461780a0d"
+  integrity sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.2.4"
+
+"@img/sharp-linux-ppc64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz#9c213a81520a20caf66978f3d4c07456ff2e0813"
+  integrity sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.2.4"
+
+"@img/sharp-linux-riscv64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz#cdd28182774eadbe04f62675a16aabbccb833f60"
+  integrity sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-riscv64" "1.2.4"
+
+"@img/sharp-linux-s390x@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz#93eac601b9f329bb27917e0e19098c722d630df7"
+  integrity sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-s390x" "1.2.4"
+
+"@img/sharp-linux-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz#55abc7cd754ffca5002b6c2b719abdfc846819a8"
+  integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.2.4"
+
+"@img/sharp-linuxmusl-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz#d6515ee971bb62f73001a4829b9d865a11b77086"
+  integrity sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
+
+"@img/sharp-linuxmusl-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz#d97978aec7c5212f999714f2f5b736457e12ee9f"
+  integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+
+"@img/sharp-wasm32@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz#2f15803aa626f8c59dd7c9d0bbc766f1ab52cfa0"
+  integrity sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==
+  dependencies:
+    "@emnapi/runtime" "^1.7.0"
+
+"@img/sharp-win32-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz#3706e9e3ac35fddfc1c87f94e849f1b75307ce0a"
+  integrity sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==
+
+"@img/sharp-win32-ia32@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz#0b71166599b049e032f085fb9263e02f4e4788de"
+  integrity sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==
+
+"@img/sharp-win32-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
+  integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.2", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -324,10 +496,10 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
-"@next/env@14.2.35":
-  version "14.2.35"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.35.tgz#e979016d0ca8500a47d41ffd02625fe29b8df35a"
-  integrity sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==
+"@next/env@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.5.21.tgz#782aa4d6b08ddfd12ac7e17ca85b7ee1b61c500b"
+  integrity sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==
 
 "@next/eslint-plugin-next@16.0.0":
   version "16.0.0"
@@ -336,50 +508,45 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-darwin-arm64@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz#9e74a4223f1e5e39ca4f9f85709e0d95b869b298"
-  integrity sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==
+"@next/swc-darwin-arm64@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.21.tgz#bac5a07fc86a50555e0bab64fc7446605b028df4"
+  integrity sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==
 
-"@next/swc-darwin-x64@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz#fcf0c45938da9b0cc2ec86357d6aefca90bd17f3"
-  integrity sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==
+"@next/swc-darwin-x64@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.21.tgz#b369644e8e5f0b3b51469542fc7d724c23762946"
+  integrity sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==
 
-"@next/swc-linux-arm64-gnu@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz#837f91a740eb4420c06f34c4677645315479d9be"
-  integrity sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==
+"@next/swc-linux-arm64-gnu@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.21.tgz#90d8033f1411b1f1cd834d8d0b13daa6c1e978ac"
+  integrity sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==
 
-"@next/swc-linux-arm64-musl@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz#dc8903469e5c887b25e3c2217a048bd30c58d3d4"
-  integrity sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==
+"@next/swc-linux-arm64-musl@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.21.tgz#fa3359b5d8e50d24a47d3f24fd663dd29b751abb"
+  integrity sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==
 
-"@next/swc-linux-x64-gnu@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz#344438be592b6b28cc540194274561e41f9933e5"
-  integrity sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==
+"@next/swc-linux-x64-gnu@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.21.tgz#8df24c447815a9d7c71c86209607fb2340275837"
+  integrity sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==
 
-"@next/swc-linux-x64-musl@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz#3379fad5e0181000b2a4fac0b80f7ca4ffe795c8"
-  integrity sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==
+"@next/swc-linux-x64-musl@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.21.tgz#eec68325de1fa0c708c031754bd0310d145d9424"
+  integrity sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==
 
-"@next/swc-win32-arm64-msvc@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz#bca8f4dde34656aef8e99f1e5696de255c2f00e5"
-  integrity sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==
+"@next/swc-win32-arm64-msvc@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.21.tgz#d5fdddb7a96bc549ce2581a50c44bb9b44db0942"
+  integrity sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==
 
-"@next/swc-win32-ia32-msvc@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz#a69c581483ea51dd3b8907ce33bb101fe07ec1df"
-  integrity sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==
-
-"@next/swc-win32-x64-msvc@14.2.33":
-  version "14.2.33"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz#f1a40062530c17c35a86d8c430b3ae465eb7cea1"
-  integrity sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==
+"@next/swc-win32-x64-msvc@15.5.21":
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.21.tgz#762363d4aaa353775b3c7a03e202f9eb0b1dca9e"
+  integrity sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==
 
 "@noble/ciphers@^0.5.1":
   version "0.5.3"
@@ -445,6 +612,13 @@
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
+
+"@playwright/test@^1.58.2":
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.62.1.tgz#68e1aaf6e480e1923936dee6c66fae1921d3a65a"
+  integrity sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==
+  dependencies:
+    playwright "1.62.1"
 
 "@radix-ui/primitive@1.1.3":
   version "1.1.3"
@@ -748,18 +922,12 @@
     "@noble/hashes" "~1.3.0"
     "@scure/base" "~1.1.0"
 
-"@swc/counter@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
-  integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
-
-"@swc/helpers@0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.5.tgz#12689df71bfc9b21c4f4ca00ae55f2f16c8b77c0"
-  integrity sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==
+"@swc/helpers@0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
+  integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
   dependencies:
-    "@swc/counter" "^0.1.3"
-    tslib "^2.4.0"
+    tslib "^2.8.0"
 
 "@tabler/icons-react@^2.40.0":
   version "2.47.0"
@@ -1270,13 +1438,6 @@ browserslist@^4.24.0, browserslist@^4.28.1:
     node-releases "^2.0.27"
     update-browserslist-db "^1.2.0"
 
-busboy@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
-  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
-  dependencies:
-    streamsearch "^1.1.0"
-
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -1465,6 +1626,11 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+detect-libc@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-node-es@^1.1.0:
   version "1.1.0"
@@ -1998,9 +2164,9 @@ flat-cache@^4.0.0:
     keyv "^4.5.4"
 
 flatted@^3.2.9:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
-  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.4.tgz#aeeca2a506303f0cee61c59e6c9f2a88d2f29fc6"
+  integrity sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -2022,6 +2188,11 @@ fs-extra@^10.0.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@~2.3.2:
   version "2.3.3"
@@ -2142,7 +2313,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11:
+graceful-fs@^4.1.11, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2486,9 +2657,9 @@ jiti@^1.21.7:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.2.tgz#8e44fb14a2643c59726bb15787b5f1512cb3d3fb"
+  integrity sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==
   dependencies:
     argparse "^2.0.1"
 
@@ -2680,10 +2851,10 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.11, nanoid@^3.3.6:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+nanoid@^3.3.16, nanoid@^3.3.6:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 napi-postinstall@^0.3.0:
   version "0.3.4"
@@ -2695,28 +2866,26 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next@14.2.35:
-  version "14.2.35"
-  resolved "https://registry.yarnpkg.com/next/-/next-14.2.35.tgz#7c68873a15fe5a19401f2f993fea535be3366ee9"
-  integrity sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==
+next@15.5.21:
+  version "15.5.21"
+  resolved "https://registry.yarnpkg.com/next/-/next-15.5.21.tgz#43355e37f9d1ed8cf96018aa57f84ea2ec213f7b"
+  integrity sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==
   dependencies:
-    "@next/env" "14.2.35"
-    "@swc/helpers" "0.5.5"
-    busboy "1.6.0"
+    "@next/env" "15.5.21"
+    "@swc/helpers" "0.5.15"
     caniuse-lite "^1.0.30001579"
-    graceful-fs "^4.2.11"
     postcss "8.4.31"
-    styled-jsx "5.1.1"
+    styled-jsx "5.1.6"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "14.2.33"
-    "@next/swc-darwin-x64" "14.2.33"
-    "@next/swc-linux-arm64-gnu" "14.2.33"
-    "@next/swc-linux-arm64-musl" "14.2.33"
-    "@next/swc-linux-x64-gnu" "14.2.33"
-    "@next/swc-linux-x64-musl" "14.2.33"
-    "@next/swc-win32-arm64-msvc" "14.2.33"
-    "@next/swc-win32-ia32-msvc" "14.2.33"
-    "@next/swc-win32-x64-msvc" "14.2.33"
+    "@next/swc-darwin-arm64" "15.5.21"
+    "@next/swc-darwin-x64" "15.5.21"
+    "@next/swc-linux-arm64-gnu" "15.5.21"
+    "@next/swc-linux-arm64-musl" "15.5.21"
+    "@next/swc-linux-x64-gnu" "15.5.21"
+    "@next/swc-linux-x64-musl" "15.5.21"
+    "@next/swc-win32-arm64-msvc" "15.5.21"
+    "@next/swc-win32-x64-msvc" "15.5.21"
+    sharp "^0.34.3"
 
 node-releases@^2.0.27:
   version "2.0.27"
@@ -2927,6 +3096,20 @@ pirates@^4.0.1:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
+playwright-core@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.62.1.tgz#120f67a19181bfd183c60fa903c0d99330b56785"
+  integrity sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==
+
+playwright@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.62.1.tgz#8447b6755e8aec85a3cb7207c823e3ed2fc66700"
+  integrity sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==
+  dependencies:
+    playwright-core "1.62.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
@@ -2985,11 +3168,11 @@ postcss@8.4.31:
     source-map-js "^1.0.2"
 
 postcss@^8, postcss@^8.4.47:
-  version "8.5.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
-  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+  version "8.5.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -3264,6 +3447,40 @@ set-proto@^1.0.0:
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
 
+sharp@^0.34.3:
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.34.5.tgz#b6f148e4b8c61f1797bde11a9d1cfebbae2c57b0"
+  integrity sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==
+  dependencies:
+    "@img/colour" "^1.0.0"
+    detect-libc "^2.1.2"
+    semver "^7.7.3"
+  optionalDependencies:
+    "@img/sharp-darwin-arm64" "0.34.5"
+    "@img/sharp-darwin-x64" "0.34.5"
+    "@img/sharp-libvips-darwin-arm64" "1.2.4"
+    "@img/sharp-libvips-darwin-x64" "1.2.4"
+    "@img/sharp-libvips-linux-arm" "1.2.4"
+    "@img/sharp-libvips-linux-arm64" "1.2.4"
+    "@img/sharp-libvips-linux-ppc64" "1.2.4"
+    "@img/sharp-libvips-linux-riscv64" "1.2.4"
+    "@img/sharp-libvips-linux-s390x" "1.2.4"
+    "@img/sharp-libvips-linux-x64" "1.2.4"
+    "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+    "@img/sharp-linux-arm" "0.34.5"
+    "@img/sharp-linux-arm64" "0.34.5"
+    "@img/sharp-linux-ppc64" "0.34.5"
+    "@img/sharp-linux-riscv64" "0.34.5"
+    "@img/sharp-linux-s390x" "0.34.5"
+    "@img/sharp-linux-x64" "0.34.5"
+    "@img/sharp-linuxmusl-arm64" "0.34.5"
+    "@img/sharp-linuxmusl-x64" "0.34.5"
+    "@img/sharp-wasm32" "0.34.5"
+    "@img/sharp-win32-arm64" "0.34.5"
+    "@img/sharp-win32-ia32" "0.34.5"
+    "@img/sharp-win32-x64" "0.34.5"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -3338,11 +3555,6 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
-
-streamsearch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
-  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"
@@ -3422,10 +3634,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-styled-jsx@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.1.tgz#839a1c3aaacc4e735fed0781b8619ea5d0009d1f"
-  integrity sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==
+styled-jsx@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.6.tgz#83b90c077e6c6a80f7f5e8781d0f311b2fe41499"
+  integrity sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==
   dependencies:
     client-only "0.0.1"
 
@@ -3548,7 +3760,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Description

- brings vercel/production to master's exact tree in one commit
- production picks up next 15.5.10 (React 19 in the App Router), the dependency bumps from #68, #131 and #135, the playwright e2e suite with its component test ids, the nix based CI with build and e2e jobs, and the privacy row test id that #132 left out
- the catalog content does not change, every mod and the new-mods order already match master
- #137 is stacked on this and records master as an ancestor of production, so the next deploy is a plain merge of master

## Testing

- full e2e suite against the staging deploy of master with `E2E_BASE_URL`: 61 of 67 pass, the fedi-mode install and details flows included
- the six that fail are url-filtering tests that fail against any deployed url, and a test-id-free probe of the same interactions behaves the same on production
- two of them wait for the window load event, which third-party mod icons starve on a deployed site. the rest hit a pre-existing race in the filter hook, where two category clicks inside one navigation round trip keep only the second
