### PR TITLE
fix(filter): keep earlier picks when clicks race the navigation

### DIFF
--- a/app/hooks/useMiniAppsFilterURLState.ts
+++ b/app/hooks/useMiniAppsFilterURLState.ts
@@ -7,6 +7,9 @@ import { CountryCode, RegionCode } from "../lib/countries"
 
 const SEARCH_DEBOUNCE_MS = 500
 
+const listParam = (url: URL, key: string) =>
+    (url.searchParams.get(key) ?? "").split(",").filter(Boolean)
+
 export type MiniAppsFilterState = {
     search: string
     region: RegionCode | undefined
@@ -82,11 +85,12 @@ export function useMiniAppsFilterURLState() {
 
     const toggleCountry = useCallback(
         (countryCode: CountryCode, enabled: boolean) => {
-            const newCountries = enabled
-                ? Array.from(new Set([...urlState.countries, countryCode]))
-                : urlState.countries.filter((c) => c !== countryCode)
-
             const url = new URL(window.location.href)
+            const current = listParam(url, "countries") as Array<CountryCode>
+            const newCountries = enabled
+                ? Array.from(new Set([...current, countryCode]))
+                : current.filter((c) => c !== countryCode)
+
             if (newCountries.length > 0) {
                 url.searchParams.set("countries", newCountries.join(","))
             } else {
@@ -94,16 +98,17 @@ export function useMiniAppsFilterURLState() {
             }
             router.replace(url.pathname + url.search, { scroll: false })
         },
-        [urlState.countries, router],
+        [router],
     )
 
     const toggleCategory = useCallback(
         (categoryCode: CategoryCode, enabled: boolean) => {
-            const newCategories = enabled
-                ? Array.from(new Set([...urlState.categories, categoryCode]))
-                : urlState.categories.filter((c) => c !== categoryCode)
-
             const url = new URL(window.location.href)
+            const current = listParam(url, "categories") as Array<CategoryCode>
+            const newCategories = enabled
+                ? Array.from(new Set([...current, categoryCode]))
+                : current.filter((c) => c !== categoryCode)
+
             if (newCategories.length > 0) {
                 url.searchParams.set("categories", newCategories.join(","))
             } else {
@@ -111,7 +116,7 @@ export function useMiniAppsFilterURLState() {
             }
             router.replace(url.pathname + url.search, { scroll: false })
         },
-        [urlState.categories, router],
+        [router],
     )
 
     const resetFilters = useCallback(() => {

--- a/e2e/browser-mode/url-filtering.spec.ts
+++ b/e2e/browser-mode/url-filtering.spec.ts
@@ -14,7 +14,7 @@ test.describe("Browser Mode - URL-based Filtering", () => {
         await catalogPage.getSearchInput().fill("Boltz")
 
         // Wait for the 500ms debounce to update the URL
-        await page.waitForURL(/[?&]search=Boltz/, { timeout: 15_000 })
+        await expect(page).toHaveURL(/[?&]search=Boltz/, { timeout: 15_000 })
         expect(page.url()).toContain("search=Boltz")
     })
 
@@ -151,9 +151,7 @@ test.describe("Browser Mode - URL-based Filtering", () => {
         await catalogPage.getSearchInput().fill("")
 
         // Wait for debounce to clear the URL param
-        await page.waitForURL((url) => !url.searchParams.has("search"), {
-            timeout: 15_000,
-        })
+        await expect(page).not.toHaveURL(/[?&]search=/, { timeout: 15_000 })
         expect(page.url()).not.toContain("search=")
     })
 
@@ -171,8 +169,8 @@ test.describe("Browser Mode - URL-based Filtering", () => {
         await catalogPage.closeFilterModal()
 
         // Search should still be in URL, category should be gone
-        expect(page.url()).toContain("search=bitcoin")
-        expect(page.url()).not.toContain("categories=")
+        await expect(page).not.toHaveURL(/categories=/)
+        await expect(page).toHaveURL(/[?&]search=bitcoin/)
     })
 
     test("multiple categories in URL are comma-separated", async ({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     retries: isCI ? 1 : 0,
     workers: isCI ? 1 : undefined,
     reporter: "html",
+    expect: { timeout: 10_000 },
     use: {
         baseURL: deployedUrl ?? "http://localhost:3023",
         trace: "on-first-retry",


### PR DESCRIPTION
## Description

- picking two categories or countries quickly on the deployed catalog keeps only the second one. each toggle read the current list from the search params hook, which only refreshes after the navigation round trip, so the second click started from a list without the first pick. toggles now read the live url
- the url-filtering e2e tests waited for the window load event, which third-party mod icons starve on a deployed site, so they timed out against staging and production even though the url had updated. they now poll the url, and the expect timeout is 10s for remote targets

## Testing

- url-filtering and filter-modal specs against this branch's Vercel preview with `E2E_BASE_URL`, all pass, one flaked once and passed on retry
