### PR TITLE
build(deps): keep semver-major bumps out of the dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Description

- the first grouped bun update (#141) bundled Next 16, React 19, Tailwind 4, TypeScript 7, ESLint 10 and Zod 4 and failed build, e2e and the Vercel build
- weekly groups now stay minor and patch, so they land green. a major gets its own deliberate PR
